### PR TITLE
PEK-78 Fetch TP-forhold from ESB

### DIFF
--- a/.nais/dev.yml
+++ b/.nais/dev.yml
@@ -61,5 +61,9 @@ spec:
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
     - name: STS_URL
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
+    - name: TP_URL
+      value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
+    - name: UNT_URL
+      value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
     - name: STDOUT_LOG_OUTPUT
       value: JSON

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/config/EgressService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/config/EgressService.kt
@@ -10,7 +10,9 @@ enum class EgressService(val description: String, val gatewayUsage: GatewayUsage
     PERSONDATA("Persondata", GatewayUsage.INTERNAL),
     PENSJONSOPPTJENING("Pensjonsopptjening", GatewayUsage.INTERNAL),
     SAML_TOKEN("Gandalf STS", GatewayUsage.INTERNAL),
-    SIMULERING("Simulering", GatewayUsage.INTERNAL);
+    SIMULERING("Simulering", GatewayUsage.INTERNAL),
+    TJENESTEPENSJONSFORHOLD("Tjenestepensjonsforhold", GatewayUsage.INTERNAL),
+    USERNAME_TOKEN("SOAP UsernameToken", GatewayUsage.INTERNAL);
 
     companion object {
         val servicesAccessibleViaProxy = EgressService.values().filter { it.gatewayUsage == GatewayUsage.INTERNAL }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/token/unt/client/UsernameTokenClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/token/unt/client/UsernameTokenClient.kt
@@ -1,0 +1,7 @@
+package no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client
+
+import no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client.fssgw.dto.UsernameTokenDto
+
+interface UsernameTokenClient {
+    fun fetchUsernameToken(): UsernameTokenDto
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/token/unt/client/fssgw/dto/UsernameTokenDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/token/unt/client/fssgw/dto/UsernameTokenDto.kt
@@ -1,0 +1,3 @@
+package no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client.fssgw.dto
+
+data class UsernameTokenDto(val token: String)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tp/TjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tp/TjenestepensjonService.kt
@@ -1,0 +1,13 @@
+package no.nav.pensjon.kalkulator.tp
+
+import no.nav.pensjon.kalkulator.tech.security.ingress.PidGetter
+import no.nav.pensjon.kalkulator.tp.client.TjenestepensjonClient
+import org.springframework.stereotype.Service
+
+@Service
+class TjenestepensjonService(
+    private val tjenestepensjonClient: TjenestepensjonClient,
+    private val pidGetter: PidGetter
+) {
+    fun harTjenestepensjonsforhold() = tjenestepensjonClient.harTjenestepensjonsforhold(pidGetter.pid())
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tp/api/TjenestepensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tp/api/TjenestepensjonController.kt
@@ -1,0 +1,25 @@
+package no.nav.pensjon.kalkulator.tp.api
+
+import io.swagger.v3.oas.annotations.Operation
+import no.nav.pensjon.kalkulator.tech.time.Timed
+import no.nav.pensjon.kalkulator.tp.TjenestepensjonService
+import no.nav.pensjon.kalkulator.tp.api.dto.TjenestepensjonsforholdDto
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("api")
+class TjenestepensjonController(private val service: TjenestepensjonService) : Timed() {
+
+    @GetMapping("tpo-medlemskap")
+    @Operation(
+        summary = "Har offentlig tjenestepensjonsforhold",
+        description = "Hvorvidt den innloggede brukeren har offentlig tjenestepensjonsforhold"
+    )
+    fun harTjenestepensjonsforhold(): TjenestepensjonsforholdDto {
+        return toDto(timed(service::harTjenestepensjonsforhold, "harTjenestepensjonsforhold"))
+    }
+
+    private companion object {
+        private fun toDto(harForhold: Boolean) = TjenestepensjonsforholdDto(harForhold)
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tp/api/dto/TjenestepensjonsforholdDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tp/api/dto/TjenestepensjonsforholdDto.kt
@@ -1,0 +1,3 @@
+package no.nav.pensjon.kalkulator.tp.api.dto
+
+data class TjenestepensjonsforholdDto(val harTjenestepensjonsforhold: Boolean)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tp/client/TjenestepensjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tp/client/TjenestepensjonClient.kt
@@ -1,0 +1,7 @@
+package no.nav.pensjon.kalkulator.tp.client
+
+import no.nav.pensjon.kalkulator.person.Pid
+
+interface TjenestepensjonClient {
+    fun harTjenestepensjonsforhold(pid: Pid): Boolean
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tp/client/esb/EsbTjenestepensjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tp/client/esb/EsbTjenestepensjonClient.kt
@@ -1,0 +1,126 @@
+package no.nav.pensjon.kalkulator.tp.client.esb
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import mu.KotlinLogging
+import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.tech.security.egress.EgressAccess
+import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressService
+import no.nav.pensjon.kalkulator.tech.security.egress.config.GatewayUsage
+import no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client.UsernameTokenClient
+import no.nav.pensjon.kalkulator.tp.client.esb.dto.EnvelopeDto
+import no.nav.pensjon.kalkulator.tech.web.CustomHttpHeaders
+import no.nav.pensjon.kalkulator.tech.web.EgressException
+import no.nav.pensjon.kalkulator.tp.client.TjenestepensjonClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.util.*
+
+@Component
+class EsbTjenestepensjonClient(
+    @Value("\${tp.url}") private val baseUrl: String,
+    private val usernameTokenClient: UsernameTokenClient,
+    @Qualifier("soap") private val webClient: WebClient,
+    private val xmlMapper: XmlMapper
+) : TjenestepensjonClient {
+    private val log = KotlinLogging.logger {}
+
+    override fun harTjenestepensjonsforhold(pid: Pid): Boolean {
+        val responseXml = fetchTjenestepensjonsforholdXml(pid)
+
+        return try {
+            val dto = xmlMapper.readValue(responseXml, EnvelopeDto::class.java)
+            isForholdDefined(dto)
+        } catch (e: JsonProcessingException) {
+            log.error(e) { "Failed to process XML: $responseXml" }
+            false
+        }
+    }
+
+    private fun fetchTjenestepensjonsforholdXml(pid: Pid): String {
+        val uri = "$baseUrl$PATH"
+        val body = soapEnvelope(pid.value, soapBody(pid))
+        log.debug { "POST to URI: '$uri' with body '$body'" }
+
+        try {
+            return webClient
+                .post()
+                .uri(uri)
+                .headers(::setHeaders)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String::class.java)
+                .block()
+                ?: ""
+        } catch (e: WebClientResponseException) {
+            throw EgressException(e.responseBodyAsString, e)
+        } catch (e: RuntimeException) { // e.g. when connection broken
+            throw EgressException("Failed to GET $uri: ${e.message}", e)
+        }
+    }
+
+    private fun soapEnvelope(userId: String, body: String): String {
+        return """<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    ${soapHeader(userId)}
+    $body
+</soapenv:Envelope>"""
+    }
+
+    private fun soapHeader(userId: String): String {
+        val callId = callId()
+
+        return """<soapenv:Header>
+        <callId xmlns="uri:no.nav.applikasjonsrammeverk">$callId</callId>
+        <sc:StelvioContext xmlns="" xmlns:sc="http://www.nav.no/StelvioContextPropagation">
+            <applicationId>$APPLICATION_USER_ID</applicationId>
+            <correlationId>$callId</correlationId>
+            <userId>$userId</userId>
+        </sc:StelvioContext>
+        ${usernameToken()}
+    </soapenv:Header>"""
+    }
+
+    private fun usernameToken() = usernameTokenClient.fetchUsernameToken().token
+
+    companion object {
+        private const val PATH = "/nav-cons-pen-pselv-tjenestepensjonWeb/sca/PSELVTjenestepensjonWSEXP"
+
+        // PP01 is the old service user ID for pensjon (replaced by srvpensjon/srvpselv in most apps)
+        private const val APPLICATION_USER_ID = "PP01"
+
+        private val service = EgressService.TJENESTEPENSJONSFORHOLD
+
+        private fun callId() = UUID.randomUUID().toString()
+
+        private fun setHeaders(headers: HttpHeaders) {
+            if (service.gatewayUsage == GatewayUsage.INTERNAL) {
+                headers.setBearerAuth(EgressAccess.token(service).value)
+            }
+
+            headers[CustomHttpHeaders.CALL_ID] = callId()
+        }
+
+        private fun soapBody(pid: Pid): String {
+            return """<soapenv:Body>
+        ${specXml(pid)}
+    </soapenv:Body>"""
+        }
+
+        private fun specXml(pid: Pid): String {
+            return """<inf:finnTjenestepensjonForhold xmlns:inf="http://nav-cons-pen-pselv-tjenestepensjon/no/nav/inf">
+        <finnTjenestepensjonForholdRequest>
+          <hentSamhandlerInfo>true</hentSamhandlerInfo>
+          <fnr>${pid.value}</fnr>
+        </finnTjenestepensjonForholdRequest>
+      </inf:finnTjenestepensjonForhold>"""
+        }
+
+        private fun isForholdDefined(dto: EnvelopeDto?) =
+            dto?.body?.wrapper?.response?.forhold != null
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tp/client/esb/dto/EnvelopeDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tp/client/esb/dto/EnvelopeDto.kt
@@ -1,0 +1,58 @@
+package no.nav.pensjon.kalkulator.tp.client.esb.dto
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
+
+@JacksonXmlRootElement(namespace = "http://schemas.xmlsoap.org/soap/envelope/", localName = "Envelope")
+class EnvelopeDto {
+    @JacksonXmlProperty(namespace = "http://schemas.xmlsoap.org/soap/envelope/", localName = "Body")
+    var body: BodyDto? = null
+}
+
+class BodyDto {
+    @JacksonXmlProperty(
+        namespace = "http://nav-cons-pen-pselv-tjenestepensjon/no/nav/inf",
+        localName = "finnTjenestepensjonForholdResponse"
+    )
+    var wrapper: WrapperDto? = null
+}
+
+class WrapperDto {
+    @JacksonXmlProperty(localName = "finnTjenestepensjonForholdResponse")
+    var response: ResponseDto? = null
+}
+
+class ResponseDto {
+    @JacksonXmlProperty(localName = "fnr")
+    var pid: String? = null
+
+    @JacksonXmlProperty(localName = "tjenestepensjonForholdene")
+    var forhold: ForholdDto? = null
+}
+
+class ForholdDto {
+    var forholdId: Int? = null
+    var tssEksternId: Long? = null
+    var navn: String? = null
+    var tpNr: Int? = null
+    var harUtlandPensjon: Boolean? = null
+    var samtykkeSimuleringKode: String? = null
+    var harSimulering: Boolean? = null
+    var tjenestepensjonYtelseListe: YtelseDto? = null
+    var endringsInfo: EndringsinfoDto? = null
+}
+
+class YtelseDto {
+    var ytelseId: Int? = null
+    var innmeldtFom: String? = null //TODO date
+    var ytelseKode: String? = null
+    var ytelseBeskrivelse: String? = null
+    var iverksattFom: String? = null //TODO date
+}
+
+class EndringsinfoDto {
+    var endretAvId: String? = null
+    var opprettetAvId: String? = null
+    var endretDato: String? = null //TODO date
+    var opprettetDato: String? = null //TODO date
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ pensjon-regler.service-id=${PENSJON_REGLER_SERVICE_ID:...}
 pensjon-regler.url=${proxy.url}
 popp.url=${proxy.url}
 sts.url=${proxy.url}
+tp.url=${proxy.url}
+unt.url=${proxy.url}
 unleash.url=${UNLEASH_URL:https://unleash.nais.io/api/}
 unleash.toggle.interval=${UNLEASH_TOGGLE_INTERVAL:60}
 

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/NorskPensjonPensjonsavtaleClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/NorskPensjonPensjonsavtaleClientTest.kt
@@ -1,9 +1,8 @@
 package no.nav.pensjon.kalkulator.avtale.client.np
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration.Companion.arrangeSecurityContext
 import no.nav.pensjon.kalkulator.mock.WebClientTest
+import no.nav.pensjon.kalkulator.mock.XmlMapperFactory.xmlMapper
 import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tech.security.egress.token.saml.client.SamlTokenClient
 import no.nav.pensjon.kalkulator.tech.security.egress.token.saml.client.gandalf.dto.SamlTokenDataDto
@@ -101,11 +100,6 @@ class NorskPensjonPensjonsavtaleClientTest : WebClientTest() {
         private fun okResponse(avtale: String) = jsonResponse(HttpStatus.OK).setBody(avtale)
 
         private fun samlTokenData() = SamlTokenDataDto("", "", "", 0)
-
-        private fun xmlMapper() =
-            XmlMapper().apply {
-                disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            }
 
         private fun spec() =
             PensjonsavtaleSpec(

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/mock/WebClientTest.java
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/mock/WebClientTest.java
@@ -46,6 +46,11 @@ public abstract class WebClientTest {
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
     }
 
+    protected static MockResponse xmlResponse() {
+        return new MockResponse()
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE);
+    }
+
     protected static String baseUrl() {
         return baseUrl;
     }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/mock/XmlMapperFactory.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/mock/XmlMapperFactory.kt
@@ -1,0 +1,12 @@
+package no.nav.pensjon.kalkulator.mock
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+
+object XmlMapperFactory {
+
+    fun xmlMapper() =
+        XmlMapper().apply {
+            disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/token/unt/client/fssgw/FssGatewayUsernameTokenClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/token/unt/client/fssgw/FssGatewayUsernameTokenClientTest.kt
@@ -1,0 +1,41 @@
+package no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client.fssgw
+
+import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration.Companion.arrangeSecurityContext
+import no.nav.pensjon.kalkulator.mock.WebClientTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+
+class FssGatewayUsernameTokenClientTest : WebClientTest() {
+
+    private lateinit var client: FssGatewayUsernameTokenClient
+
+    @BeforeEach
+    fun initialize() {
+        client = FssGatewayUsernameTokenClient(baseUrl(), WebClient.create())
+    }
+
+    @Test
+    fun `fetchUsernameToken returns access token data when OK response`() {
+        arrangeSecurityContext()
+        arrange(okResponse())
+
+        val response = client.fetchUsernameToken()
+
+        assertEquals(WS_SECURITY_ELEMENT, response.token)
+    }
+
+    private companion object {
+
+        private const val WS_SECURITY_ELEMENT =
+            """<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" soapenv:mustUnderstand="1">
+                <wsse:UsernameToken>
+                    <wsse:Username>srvpselv</wsse:Username>
+                    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">&amp;secret</wsse:Password>
+                </wsse:UsernameToken>
+            </wsse:Security>"""
+
+        private fun okResponse() = jsonResponse().setBody(WS_SECURITY_ELEMENT)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tp/TjenestepensjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tp/TjenestepensjonServiceTest.kt
@@ -1,0 +1,41 @@
+package no.nav.pensjon.kalkulator.tp
+
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.tech.security.ingress.PidGetter
+import no.nav.pensjon.kalkulator.tp.client.TjenestepensjonClient
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class TjenestepensjonServiceTest {
+
+    private lateinit var service: TjenestepensjonService
+
+    @Mock
+    private lateinit var client: TjenestepensjonClient
+
+    @Mock
+    private lateinit var pidGetter: PidGetter
+
+    @BeforeEach
+    fun initialize() {
+        service = TjenestepensjonService(client, pidGetter)
+    }
+
+    @Test
+    fun `harTjenestepensjonsforhold uses specified inntekt and sivilstand`() {
+        arrangePidAndResultat()
+        val result = service.harTjenestepensjonsforhold()
+        assertTrue(result)
+    }
+
+    private fun arrangePidAndResultat() {
+        `when`(pidGetter.pid()).thenReturn(pid)
+        `when`(client.harTjenestepensjonsforhold(pid)).thenReturn(true)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tp/api/TjenestepensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tp/api/TjenestepensjonControllerTest.kt
@@ -1,0 +1,52 @@
+package no.nav.pensjon.kalkulator.tp.api
+
+import no.nav.pensjon.kalkulator.avtale.*
+import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
+import no.nav.pensjon.kalkulator.tp.TjenestepensjonService
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(TjenestepensjonController::class)
+@Import(MockSecurityConfiguration::class)
+class TjenestepensjonControllerTest {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockBean
+    private lateinit var service: TjenestepensjonService
+
+    @Test
+    fun fetchTjenestepensjonsforhold() {
+        `when`(service.harTjenestepensjonsforhold()).thenReturn(true)
+
+        mvc.perform(
+            get(URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(RESPONSE_BODY))
+    }
+
+    private companion object {
+
+        private const val URL = "/api/tpo-medlemskap"
+
+        @Language("json")
+        private const val RESPONSE_BODY = """{
+	"harTjenestepensjonsforhold": true
+}"""
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tp/client/esb/EsbTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tp/client/esb/EsbTjenestepensjonClientTest.kt
@@ -1,0 +1,151 @@
+package no.nav.pensjon.kalkulator.tp.client.esb
+
+import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration.Companion.arrangeSecurityContext
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.mock.WebClientTest
+import no.nav.pensjon.kalkulator.mock.XmlMapperFactory.xmlMapper
+import no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client.UsernameTokenClient
+import no.nav.pensjon.kalkulator.tech.security.egress.token.unt.client.fssgw.dto.UsernameTokenDto
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * ESB = Enterprise Service Bus (tjenestebuss)
+ */
+@ExtendWith(SpringExtension::class)
+class EsbTjenestepensjonClientTest : WebClientTest() {
+
+    private lateinit var client: EsbTjenestepensjonClient
+
+    @Mock
+    private lateinit var usernameTokenClient: UsernameTokenClient
+
+    @BeforeEach
+    fun initialize() {
+        `when`(usernameTokenClient.fetchUsernameToken()).thenReturn(UsernameTokenDto(WS_SECURITY_ELEMENT))
+        client = EsbTjenestepensjonClient(baseUrl(), usernameTokenClient, WebClient.create(), xmlMapper())
+    }
+
+    @Test
+    fun `harTjenestepensjonsforhold returns true when forhold exists`() {
+        arrangeSecurityContext()
+        arrange(ettForholdResponse())
+
+        val forholdExists = client.harTjenestepensjonsforhold(pid)
+
+        assertTrue(forholdExists)
+    }
+
+    @Test
+    fun `harTjenestepensjonsforhold returns false when ingen forhold`() {
+        arrangeSecurityContext()
+        arrange(ingenForholdResponse())
+
+        val forholdExists = client.harTjenestepensjonsforhold(pid)
+
+        assertFalse(forholdExists)
+    }
+
+    private companion object {
+
+        private const val WS_SECURITY_ELEMENT =
+            """<wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" soapenv:mustUnderstand="1">
+                <wsse:UsernameToken>
+                    <wsse:Username>srvpselv</wsse:Username>
+                    <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">&amp;secret</wsse:Password>
+                </wsse:UsernameToken>
+            </wsse:Security>"""
+
+
+        private const val TJENESTEPENSJONSFORHOLD_XML =
+            """<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    <soapenv:Body>
+        <inf:finnTjenestepensjonForholdResponse xmlns:inf="http://nav-cons-pen-pselv-tjenestepensjon/no/nav/inf">
+            <finnTjenestepensjonForholdResponse>
+                <fnr>12906498357</fnr>
+                <tjenestepensjonForholdene>
+                    <forholdId>22598178</forholdId>
+                    <tssEksternId>80000470761</tssEksternId>
+                    <navn>Statens pensjonskasse</navn>
+                    <tpNr>3010</tpNr>
+                    <harUtlandPensjon>false</harUtlandPensjon>
+                    <samtykkeSimuleringKode>N</samtykkeSimuleringKode>
+                    <harSimulering>false</harSimulering>
+                    <tjenestepensjonYtelseListe>
+                        <ytelseId>22587180</ytelseId>
+                        <innmeldtFom>2014-04-01</innmeldtFom>
+                        <ytelseKode>ALDER</ytelseKode>
+                        <ytelseBeskrivelse>ALDER</ytelseBeskrivelse>
+                        <iverksattFom>2022-09-20</iverksattFom>
+                    </tjenestepensjonYtelseListe>
+                    <endringsInfo>
+                        <endretAvId>srvpensjon</endretAvId>
+                        <opprettetAvId>srvpensjon</opprettetAvId>
+                        <endretDato>2022-10-20</endretDato>
+                        <opprettetDato>2022-10-20</opprettetDato>
+                        <kildeId>PP01</kildeId>
+                    </endringsInfo>
+                    <avdelingType>TPOF</avdelingType>
+                </tjenestepensjonForholdene>
+                <endringsInfo>
+                    <endretAvId>UNKNOWN</endretAvId>
+                    <opprettetAvId>UNKNOWN</opprettetAvId>
+                    <endretDato>2022-04-20</endretDato>
+                    <opprettetDato>2022-04-20</opprettetDato>
+                </endringsInfo>
+            </finnTjenestepensjonForholdResponse>
+        </inf:finnTjenestepensjonForholdResponse>
+    </soapenv:Body>
+</soapenv:Envelope>"""
+
+        private const val INGEN_TJENESTEPENSJONSFORHOLD_XML =
+            """<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    <soapenv:Body>
+        <inf:finnTjenestepensjonForholdResponse xmlns:inf="http://nav-cons-pen-pselv-tjenestepensjon/no/nav/inf">
+            <finnTjenestepensjonForholdResponse>
+                <fnr>24815797236</fnr>
+                <endringsInfo>
+                    <endretAvId>srvpensjon</endretAvId>
+                    <opprettetAvId>srvpensjon</opprettetAvId>
+                    <endretDato>2022-11-09</endretDato>
+                    <opprettetDato>2022-11-09</opprettetDato>
+                </endringsInfo>
+            </finnTjenestepensjonForholdResponse>
+        </inf:finnTjenestepensjonForholdResponse>
+    </soapenv:Body>
+</soapenv:Envelope>"""
+
+        private const val FAULT_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    <soapenv:Body>
+        <soapenv:Fault xmlns:m="http://schemas.xmlsoap.org/soap/envelope/">
+            <faultcode>m:Server</faultcode>
+            <faultstring>ServerException</faultstring>
+            <detail>
+                <inf:finnTjenestepensjonForhold_faultPenGenerisk xmlns:inf="http://nav-cons-pen-pselv-tjenestepensjon/no/nav/inf">
+                    <errorMessage>Pid validation failed</errorMessage>
+                    <errorSource>Interaction: [invoke,hentTjenestepensjonInfo]</errorSource>
+                    <errorType>Runtime</errorType>
+                    <rootCause>65915200188 is not a valid personal identification number</rootCause>
+                    <dateTimeStamp>Tue Jun 13 15:41:29 CEST 2023</dateTimeStamp>
+                </inf:finnTjenestepensjonForhold_faultPenGenerisk>
+            </detail>
+        </soapenv:Fault>
+    </soapenv:Body>
+</soapenv:Envelope>"""
+
+        private fun ettForholdResponse() = xmlResponse().setBody(TJENESTEPENSJONSFORHOLD_XML)
+
+        private fun ingenForholdResponse() = xmlResponse().setBody(INGEN_TJENESTEPENSJONSFORHOLD_XML)
+
+        private fun faultResponse() = xmlResponse().setBody(FAULT_XML) //TODO fault handling
+    }
+}


### PR DESCRIPTION
Henter tjenestepensjonsforhold fra tjenestebussen (SOAP-kall med UsernameToken-autentisering).
UsernameToken er web service-varianten av "Basic auth" (brukernavn+passord).
Brukernavnet er servicebruker `srvpselv`.
Passordet til servicebruker bør helst bare finnes i FSS (ikke i GCP). Derfor hentes UsernameToken fra FSS-gateway.

Responsen brukes nå bare til å sjekke om det finnes et TP-forhold. Dette brukes så i backend-API-et til å returnere
```
{
    "harTjenestepensjonsforhold": true/false
}
```
på `GET api/tpo-medlemskap`