### PR TITLE
PEK-141 simuleringstype >> simuleringType

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/UttaksalderService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/UttaksalderService.kt
@@ -31,7 +31,7 @@ class UttaksalderService(
             sivilstand = specDto.sivilstand ?: sivilstand(pid),
             harEps = specDto.harEps ?: false,
             sisteInntekt = specDto.sisteInntekt ?: sistePensjonsgivendeInntekt(pid),
-            simuleringType = specDto.simuleringType ?: SimuleringType.ALDERSPENSJON,
+            simuleringstype = specDto.simuleringstype ?: SimuleringType.ALDERSPENSJON,
         )
 
         log.info { "Finner første mulige uttaksalder med parametre $uttaksalderSpec" }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/UttaksalderSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/UttaksalderSpec.kt
@@ -9,5 +9,5 @@ data class UttaksalderSpec(
     val sivilstand: Sivilstand,
     val harEps: Boolean,
     val sisteInntekt: Int,
-    val simuleringType: SimuleringType,
+    val simuleringstype: SimuleringType,
 )

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/dto/UttaksalderIngressSpecDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/dto/UttaksalderIngressSpecDto.kt
@@ -7,7 +7,7 @@ data class UttaksalderIngressSpecDto(
     val sivilstand: Sivilstand?,
     val harEps: Boolean?,
     val sisteInntekt: Int?,
-    val simuleringType: SimuleringType?,
+    val simuleringstype: SimuleringType?,
 ) {
     companion object {
         fun empty() = UttaksalderIngressSpecDto(null, null, null, null)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/client/pen/map/PenUttaksalderMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/client/pen/map/PenUttaksalderMapper.kt
@@ -23,7 +23,7 @@ object PenUttaksalderMapper {
             sivilstand = PenSivilstand.fromInternalValue(spec.sivilstand).externalValue,
             harEps = spec.harEps,
             sisteInntekt = spec.sisteInntekt,
-            simuleringType = PenSimuleringstype.fromInternalValue(spec.simuleringType).externalValue,
+            simuleringType = PenSimuleringstype.fromInternalValue(spec.simuleringstype).externalValue,
         )
 
     private fun oneBasedMaaned(zeroBasedMaaned: Int) =

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/UttaksalderControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/UttaksalderControllerTest.kt
@@ -76,7 +76,7 @@ internal class UttaksalderControllerTest {
               "sivilstand": "$sivilstand",
               "harEps": $harEps,
               "sisteInntekt": $sisteInntekt,
-              "simuleringType": "${simuleringType.name}"
+              "simuleringstype": "${simuleringType.name}"
             }
         """.trimIndent()
 


### PR DESCRIPTION
[simulerAlderspensjonV1](https://pensjonskalkulator-backend.intern.dev.nav.no/swagger-ui/index.html#/simulering-controller/simulerAlderspensjonV1) har `simuleringstype` fra før. Greit å ha likt på tvers av controllere