### PR TITLE
add resources and limits to prod instances

### DIFF
--- a/.nais/deploy-prod.yml
+++ b/.nais/deploy-prod.yml
@@ -10,7 +10,7 @@ spec:
   port: 8080
   replicas:
     min: 2
-    max: 2
+    max: 4
   ingresses:
     - https://pensjonskalkulator-backend.intern.nav.no
   liveness:
@@ -25,6 +25,14 @@ spec:
   prometheus:
     enabled: true
     path: /internal/prometheus
+  resources:
+    limits:
+      cpu: "2"
+      memory: "2048Mi"
+    requests:
+      cpu: "1"
+      memory: "1024Mi"
+  cpuThresholdPercentage: 70
   azure:
     application:
       enabled: true


### PR DESCRIPTION
Setter initielle verdier etter å se på stress-test minne og CPU-bruk i dev-miljø. Riktige verdier finner vi sannsynligvis etter offentliggjøring av appen. [https://grafana.nais.io/d/0Qx_7cA4k/pensjonskalkulator?orgId=...](https://grafana.nais.io/d/0Qx_7cA4k/pensjonskalkulator?orgId=1&var-datasource=dev-gcp&var-app=pensjonskalkulator-backend&var-namespace=pensjonskalkulator&var-interval=2m&from=1696971051772&to=1696974351288)

**Minne**
1GB initiell minne, 2GB limit: det ble brukt ca 1GB i gjennomsnitt i løpet av stresstesten, ved 2GB minne sleit poddene.

**CPU**
1 kjerne initiell, 2 kjerner - limit: 1 kjerne ble brukt ved spikes som backend klarte å fordøye, 2-3 kjerner var toppen før restart

`cpuThresholdPercentage: 70` - oppskalering ved 70% CPU-bruk (default 50)