### PR TITLE
legg til simulerAlderspensjon V6 med AFP offentlig uten afpleverandørnavn

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/SimulertAfpOffentlig.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/SimulertAfpOffentlig.kt
@@ -1,3 +1,3 @@
 package no.nav.pensjon.kalkulator.simulering
 
-data class SimulertAfpOffentlig(val alder: Int, val beloep: Int, val afpLeverandoer: String)
+data class SimulertAfpOffentlig(val alder: Int, val beloep: Int, val afpLeverandoer: String) //TODO fjerne når frontend vil gå over til "simulerAlderspensjonV6"

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/IngressSimuleringSpecV6.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/IngressSimuleringSpecV6.kt
@@ -1,0 +1,41 @@
+package no.nav.pensjon.kalkulator.simulering.api.dto
+
+import no.nav.pensjon.kalkulator.person.Sivilstand
+import no.nav.pensjon.kalkulator.simulering.SimuleringType
+import java.time.LocalDate
+
+/**
+ * Incoming (ingress) data transfer object (DTO) containing specification for 'simulering av alderspensjon'.
+ */
+data class IngressSimuleringSpecV6(
+    val simuleringstype: SimuleringType,
+    val foedselsdato: LocalDate,
+    val epsHarInntektOver2G: Boolean,
+    val aarligInntektFoerUttakBeloep: Int?,
+    val sivilstand: Sivilstand?,
+    val gradertUttak: IngressSimuleringGradertUttakV6? = null, // default is helt uttak (100 %)
+    val heltUttak: IngressSimuleringHeltUttakV6
+)
+
+data class IngressSimuleringGradertUttakV6(
+    val grad: Int,
+    val uttaksalder: IngressSimuleringAlderV6,
+    val aarligInntektVsaPensjonBeloep: Int?
+)
+
+data class IngressSimuleringHeltUttakV6(
+    val uttaksalder: IngressSimuleringAlderV6,
+    val aarligInntektVsaPensjon: IngressSimuleringInntektV6?
+)
+
+data class IngressSimuleringInntektV6(
+    val beloep: Int,
+    val sluttAlder: IngressSimuleringAlderV6
+)
+
+data class IngressSimuleringAlderV6(val aar: Int, val maaneder: Int) {
+    init {
+        require(aar in 0..200) { "0 <= aar <= 200" }
+        require(maaneder in 0..11) { "0 <= maaneder <= 11" }
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/SimuleringResultatV6.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/SimuleringResultatV6.kt
@@ -1,0 +1,32 @@
+package no.nav.pensjon.kalkulator.simulering.api.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class SimuleringResultatV6(
+    val alderspensjon: List<PensjonsberegningV6> = emptyList(),
+    val afpPrivat: AfpPrivatV6? = null,
+    val afpOffentlig: AfpOffentligV6? = null,
+    val vilkaarsproeving: VilkaarsproevingV6
+)
+
+data class PensjonsberegningV6(val alder: Int, val beloep: Int)
+
+data class AfpPrivatV6(val afpPrivatListe: List<PensjonsberegningV6>)
+
+data class AfpOffentligV6(val afpOffentligListe: List<PensjonsberegningAfpOffentligV6>)
+
+data class PensjonsberegningAfpOffentligV6(val alder: Int, val beloep: Int)
+
+data class VilkaarsproevingV6(
+    val vilkaarErOppfylt: Boolean,
+    val alternativ: AlternativV6?
+)
+
+data class AlternativV6(
+    val gradertUttaksalder: AlderV6?,
+    val uttaksgrad: Int?, // null implies 100 %
+    val heltUttaksalder: AlderV6
+)
+
+data class AlderV6(val aar: Int, val maaneder: Int)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/SimuleringResultatV6.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/SimuleringResultatV6.kt
@@ -5,16 +5,12 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class SimuleringResultatV6(
     val alderspensjon: List<PensjonsberegningV6> = emptyList(),
-    val afpPrivat: AfpPrivatV6? = null,
-    val afpOffentlig: AfpOffentligV6? = null,
+    val afpPrivat: List<PensjonsberegningV6>? = emptyList(),
+    val afpOffentlig: List<PensjonsberegningAfpOffentligV6>? = emptyList(),
     val vilkaarsproeving: VilkaarsproevingV6
 )
 
 data class PensjonsberegningV6(val alder: Int, val beloep: Int)
-
-data class AfpPrivatV6(val afpPrivatListe: List<PensjonsberegningV6>)
-
-data class AfpOffentligV6(val afpOffentligListe: List<PensjonsberegningAfpOffentligV6>)
 
 data class PensjonsberegningAfpOffentligV6(val alder: Int, val beloep: Int)
 

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/SimuleringMapperV6.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/SimuleringMapperV6.kt
@@ -23,8 +23,8 @@ object SimuleringMapperV6 {
     fun resultatV6(source: Simuleringsresultat) =
         SimuleringResultatV6(
             alderspensjon = source.alderspensjon.map { PensjonsberegningV6(it.alder, it.beloep) },
-            afpPrivat = if (source.afpPrivat.isEmpty()) null else AfpPrivatV6(source.afpPrivat.map { PensjonsberegningV6(it.alder, it.beloep) }),
-            afpOffentlig = if (source.afpOffentlig.isEmpty()) null else AfpOffentligV6(source.afpOffentlig.map { PensjonsberegningAfpOffentligV6(it.alder, it.beloep) }),
+            afpPrivat = source.afpPrivat.map { PensjonsberegningV6(it.alder, it.beloep) },
+            afpOffentlig = source.afpOffentlig.map { PensjonsberegningAfpOffentligV6(it.alder, it.beloep) },
             vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving)
         )
 

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/SimuleringMapperV6.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/SimuleringMapperV6.kt
@@ -1,0 +1,71 @@
+package no.nav.pensjon.kalkulator.simulering.api.map
+
+import no.nav.pensjon.kalkulator.general.*
+import no.nav.pensjon.kalkulator.simulering.*
+import no.nav.pensjon.kalkulator.simulering.api.dto.*
+
+/**
+ * Maps between data transfer objects (DTOs) and domain objects related to simulering.
+ * The DTOs are specified by version 5 of the API offered to clients.
+ */
+object SimuleringMapperV6 {
+
+    fun fromIngressSimuleringSpecV6(dto: IngressSimuleringSpecV6) =
+        ImpersonalSimuleringSpec(
+            simuleringType = dto.simuleringstype,
+            epsHarInntektOver2G = dto.epsHarInntektOver2G,
+            forventetAarligInntektFoerUttak = dto.aarligInntektFoerUttakBeloep,
+            sivilstand = dto.sivilstand,
+            gradertUttak = dto.gradertUttak?.let(::gradertUttak),
+            heltUttak = heltUttak(dto.heltUttak)
+        )
+
+    fun resultatV6(source: Simuleringsresultat) =
+        SimuleringResultatV6(
+            alderspensjon = source.alderspensjon.map { PensjonsberegningV6(it.alder, it.beloep) },
+            afpPrivat = if (source.afpPrivat.isEmpty()) null else AfpPrivatV6(source.afpPrivat.map { PensjonsberegningV6(it.alder, it.beloep) }),
+            afpOffentlig = if (source.afpOffentlig.isEmpty()) null else AfpOffentligV6(source.afpOffentlig.map { PensjonsberegningAfpOffentligV6(it.alder, it.beloep) }),
+            vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving)
+        )
+
+    private fun gradertUttak(dto: IngressSimuleringGradertUttakV6) =
+        GradertUttak(
+            grad = Uttaksgrad.from(dto.grad),
+            uttakFomAlder = alder(dto.uttaksalder),
+            aarligInntekt = dto.aarligInntektVsaPensjonBeloep ?: 0
+        )
+
+    private fun heltUttak(dto: IngressSimuleringHeltUttakV6) =
+        HeltUttak(
+            uttakFomAlder = alder(dto.uttaksalder),
+            inntekt = dto.aarligInntektVsaPensjon?.let(::inntekt)
+        )
+
+    private fun inntekt(dto: IngressSimuleringInntektV6) =
+        Inntekt(
+            aarligBeloep = dto.beloep,
+            tomAlder = dto.sluttAlder.let(::alder)
+        )
+
+    private fun alder(dto: IngressSimuleringAlderV6) = Alder(dto.aar, dto.maaneder)
+
+    private fun vilkaarsproeving(source: Vilkaarsproeving) =
+        VilkaarsproevingV6(
+            vilkaarErOppfylt = source.innvilget,
+            alternativ = source.alternativ?.let(::alternativ)
+        )
+
+    private fun alternativ(source: Alternativ) =
+        AlternativV6(
+            gradertUttaksalder = source.gradertUttakAlder?.let(::alder),
+            uttaksgrad = prosentsats(source.uttakGrad),
+            heltUttaksalder = alder(source.heltUttakAlder)
+        )
+
+    private fun prosentsats(grad: Uttaksgrad?): Int? =
+        grad?.let {
+            if (it == Uttaksgrad.HUNDRE_PROSENT) null else it.prosentsats
+        }
+
+    private fun alder(source: Alder) = AlderV6(source.aar, source.maaneder)
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/pen/dto/PenSimuleringResultDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/pen/dto/PenSimuleringResultDto.kt
@@ -15,7 +15,7 @@ data class PenPensjonDto(
 data class PenPensjonAfpOffentligDto(
     val alder: Int,
     val beloep: Int,
-    val tpOrdning: String,
+    val tpOrdning: String, //TODO fjerne når frontend vil gå over til "simulerAlderspensjonV6"
 )
 
 data class PenVilkaarsproevingDto(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
@@ -34,6 +34,7 @@ class OpenApiConfiguration {
         return GroupedOpenApi.builder()
             .group("current")
             .pathsToMatch(
+                "/api/v6/alderspensjon/simulering",
                 "/api/v5/alderspensjon/simulering",
                 "/api/v4/alderspensjon/simulering",
                 "/api/v3/alderspensjon/simulering", // to be moved to 'deprecated'

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
@@ -61,6 +61,7 @@ class SimuleringControllerTest {
             .andExpect(content().json(responseBodyV4(SimuleringType.ALDERSPENSJON)))
     }
 
+
     @Test
     fun `simulerer hel alderspensjon V5`() {
         val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON)
@@ -74,6 +75,21 @@ class SimuleringControllerTest {
         )
             .andExpect(status().isOk())
             .andExpect(content().json(responseBodyV5()))
+    }
+
+    @Test
+    fun `simulerer hel alderspensjon V6`() {
+        val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON)
+        `when`(simuleringService.simulerAlderspensjon(spec)).thenReturn(simuleringsresultat(spec.simuleringType))
+
+        mvc.perform(
+            post(URL_V6)
+                .with(csrf())
+                .content(heltUttakRequestBody(SimuleringType.ALDERSPENSJON))
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(responseBodyV6()))
     }
 
     @Test
@@ -107,6 +123,22 @@ class SimuleringControllerTest {
     }
 
     @Test
+    fun `simulerer alderspensjon med gradert uttak V6`() {
+        val spec = impersonalGradertUttakSpec()
+        `when`(simuleringService.simulerAlderspensjon(spec)).thenReturn(simuleringsresultat(spec.simuleringType))
+
+        mvc.perform(
+            post(URL_V6)
+                .with(csrf())
+                .content(gradertUttakRequestBody())
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(responseBodyV6()))
+    }
+
+
+    @Test
     fun `simulerer alderspensjon med AFP privat`() {
         val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON_MED_AFP_PRIVAT)
         `when`(simuleringService.simulerAlderspensjon(spec)).thenReturn(simuleringsresultat(spec.simuleringType))
@@ -138,6 +170,21 @@ class SimuleringControllerTest {
 
 
     @Test
+    fun `simulerer alderspensjon med AFP privat V6`() {
+        val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON_MED_AFP_PRIVAT)
+        `when`(simuleringService.simulerAlderspensjon(spec)).thenReturn(simuleringsresultat(spec.simuleringType))
+
+        mvc.perform(
+            post(URL_V6)
+                .with(csrf())
+                .content(heltUttakRequestBody(SimuleringType.ALDERSPENSJON_MED_AFP_PRIVAT))
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(responseBodyV6MedAfpPrivat()))
+    }
+
+    @Test
     fun `simulerer alderspensjon med AFP offentlig`() {
         val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG)
         `when`(simuleringService.simulerAlderspensjon(spec)).thenReturn(simuleringsresultat(spec.simuleringType))
@@ -165,6 +212,21 @@ class SimuleringControllerTest {
         )
             .andExpect(status().isOk())
             .andExpect(content().json(responseBodyV5MedAFPOffentlig()))
+    }
+
+    @Test
+    fun `simulerer alderspensjon med AFP offentlig V6`() {
+        val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG)
+        `when`(simuleringService.simulerAlderspensjon(spec)).thenReturn(simuleringsresultat(spec.simuleringType))
+
+        mvc.perform(
+            post(URL_V6)
+                .with(csrf())
+                .content(heltUttakRequestBody(SimuleringType.ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG))
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(responseBodyV6MedAFPOffentlig()))
     }
 
 
@@ -198,11 +260,27 @@ class SimuleringControllerTest {
             .andExpect(content().json(SimuleringController.VILKAAR_IKKE_OPPFYLT_EXAMPLE_V5))
     }
 
+    @Test
+    fun `simulering responds 'vilkaar ikke oppfylt' when Conflict V6`() {
+        val spec = impersonalHeltUttakSpec(SimuleringType.ALDERSPENSJON_MED_AFP_PRIVAT)
+        `when`(simuleringService.simulerAlderspensjon(spec)).thenThrow(conflict())
+
+        mvc.perform(
+            post(URL_V6)
+                .with(csrf())
+                .content(heltUttakRequestBody(SimuleringType.ALDERSPENSJON_MED_AFP_PRIVAT))
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(SimuleringController.VILKAAR_IKKE_OPPFYLT_EXAMPLE_V6))
+    }
+
 
     private companion object {
 
         private const val URL_V4 = "/api/v4/alderspensjon/simulering"
         private const val URL_V5 = "/api/v5/alderspensjon/simulering"
+        private const val URL_V6 = "/api/v6/alderspensjon/simulering"
         private const val PENSJONSBELOEP = 123456
 
         @Language("json")
@@ -280,6 +358,16 @@ class SimuleringControllerTest {
             }""".trimIndent()
 
         @Language("json")
+        private fun responseBodyV6() = """{
+            "alderspensjon": [
+              {
+                "beloep": $PENSJONSBELOEP,
+                "alder": 67
+              }
+            ]
+            }""".trimIndent()
+
+        @Language("json")
         private fun responseBodyV4(simuleringstype: SimuleringType) = """{
             "alderspensjon": [
               {
@@ -304,6 +392,26 @@ class SimuleringControllerTest {
 
         @Language("json")
         private fun responseBodyV5MedAfpPrivat() = """{
+            "alderspensjon": [
+              {
+                "beloep": $PENSJONSBELOEP,
+                "alder": 67
+              }
+            ],
+            "afpPrivat": {
+              "afpPrivatListe":
+              [
+                {
+                  "beloep": 22056,
+                  "alder": 67
+                }
+              ]
+              }
+            }
+        }""".trimIndent()
+
+        @Language("json")
+        private fun responseBodyV6MedAfpPrivat() = """{
             "alderspensjon": [
               {
                 "beloep": $PENSJONSBELOEP,
@@ -353,6 +461,26 @@ class SimuleringControllerTest {
             ],
             "afpOffentlig": {
               "afpLeverandoer": "Statens pensjonskasse",
+              "afpOffentligListe": [
+                  {
+                    "beloep": 22056,
+                    "alder": 67
+                  }
+                ]
+              }
+              }
+              """.trimIndent()
+
+
+        @Language("json")
+        private fun responseBodyV6MedAFPOffentlig() = """{
+            "alderspensjon": [
+              {
+                "beloep": $PENSJONSBELOEP,
+                "alder": 67
+              }
+            ],
+            "afpOffentlig": {
               "afpOffentligListe": [
                   {
                     "beloep": 22056,

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
@@ -418,15 +418,13 @@ class SimuleringControllerTest {
                 "alder": 67
               }
             ],
-            "afpPrivat": {
-              "afpPrivatListe":
+            "afpPrivat": 
               [
                 {
                   "beloep": 22056,
                   "alder": 67
                 }
               ]
-              }
             }
         }""".trimIndent()
 
@@ -480,14 +478,12 @@ class SimuleringControllerTest {
                 "alder": 67
               }
             ],
-            "afpOffentlig": {
-              "afpOffentligListe": [
+            "afpOffentlig": [
                   {
                     "beloep": 22056,
                     "alder": 67
                   }
                 ]
-              }
               }
               """.trimIndent()
 


### PR DESCRIPTION
En ren kopi av V5. AFP Offentlig skal se sånn ut i V6 (som AfpPrivat):
```
"afpOffentlig": {
              "afpOffentligListe": [
                  {
                    "beloep": 22056,
                    "alder": 67
                  }
                ]
              }
```