### PR TITLE
PEK-424 bytt endepunkt for å hente navn på tp-ordninger hvor bruker er medlem i

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/FinnTjenestepensjonsforholdResponsDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/FinnTjenestepensjonsforholdResponsDto.kt
@@ -1,0 +1,11 @@
+package no.nav.pensjon.kalkulator.tjenestepensjon
+
+import java.time.LocalDate
+
+data class FinnTjenestepensjonsforholdResponsDto(val fnr: String, val forhold: List<ForholdDto>? = emptyList())
+
+data class ForholdDto(val ordning: OrdningDto, val ytelser: List<YtelseDto>?)
+
+data class OrdningDto(val navn: String, val tpNr: String)
+
+data class YtelseDto(val ytelseType: String, val datoInnmeldtYtelseFom: LocalDate?, val datoYtelseIverksattFom: LocalDate?, val datoYtelseIverksattTom: LocalDate?)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/Tjenestepensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/Tjenestepensjon.kt
@@ -16,3 +16,5 @@ data class Ytelse(
     val datoYtelseIverksattFom: LocalDate?,
     val datoYtelseIverksattTom: LocalDate?
 )
+
+data class Tjenestepensjonsforhold(val tpOrdninger: List<String>)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/TjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/TjenestepensjonService.kt
@@ -13,7 +13,7 @@ class TjenestepensjonService(
 ) {
     fun harTjenestepensjonsforhold() = harForhold(tjenestepensjonClient.tjenestepensjon(pidGetter.pid()))
 
-    fun hentMedlemskapITjenestepensjonsordninger() = forholdsListe(tjenestepensjonClient.tjenestepensjon(pidGetter.pid()))
+    fun hentMedlemskapITjenestepensjonsordninger() = tjenestepensjonClient.tjenestepensjonsforhold(pidGetter.pid()).tpOrdninger
 
     fun erApoteker(): Boolean =
         if (featureToggleService.isEnabled("mock-norsk-pensjon") && pidGetter.pid().value == "18870199488")
@@ -25,7 +25,5 @@ class TjenestepensjonService(
         private fun harForhold(tjenestepensjon: Tjenestepensjon): Boolean =
             tjenestepensjon.forholdList.isNotEmpty()
 
-        private fun forholdsListe (tjenestepensjon: Tjenestepensjon): List<String> =
-            tjenestepensjon.forholdList.map { it.ordning }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/TjenestepensjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/TjenestepensjonClient.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.kalkulator.tjenestepensjon.client
 
 import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.tjenestepensjon.Tjenestepensjonsforhold
 import no.nav.pensjon.kalkulator.tjenestepensjon.Tjenestepensjon
 import java.time.LocalDate
 
@@ -11,4 +12,6 @@ interface TjenestepensjonClient {
     fun erApoteker(pid: Pid): Boolean
 
     fun tjenestepensjon(pid: Pid): Tjenestepensjon
+
+    fun tjenestepensjonsforhold(pid: Pid) : Tjenestepensjonsforhold
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/tp/map/TpTjenestepensjonMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/tp/map/TpTjenestepensjonMapper.kt
@@ -1,8 +1,6 @@
 package no.nav.pensjon.kalkulator.tjenestepensjon.client.tp.map
 
-import no.nav.pensjon.kalkulator.tjenestepensjon.Forhold
-import no.nav.pensjon.kalkulator.tjenestepensjon.Tjenestepensjon
-import no.nav.pensjon.kalkulator.tjenestepensjon.Ytelse
+import no.nav.pensjon.kalkulator.tjenestepensjon.*
 import no.nav.pensjon.kalkulator.tjenestepensjon.client.tp.dto.*
 
 object TpTjenestepensjonMapper {
@@ -13,6 +11,9 @@ object TpTjenestepensjonMapper {
 
     fun fromDto(dto: TpTjenestepensjonDto): Tjenestepensjon =
         Tjenestepensjon(dto.forhold?.map(::forhold).orEmpty())
+
+    fun fromDto(dto: FinnTjenestepensjonsforholdResponsDto): Tjenestepensjonsforhold =
+        Tjenestepensjonsforhold(dto.forhold.orEmpty().map { it.ordning.navn })
 
     private fun forhold(dto: TpForholdDto): Forhold =
         Forhold(

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/TjenestepensjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/TjenestepensjonServiceTest.kt
@@ -47,7 +47,7 @@ class TjenestepensjonServiceTest {
 
     @Test
     fun `gir liste over alle medlemskap i tp-ordninger`() {
-        `when`(client.tjenestepensjon(pid)).thenReturn(tjenestepensjonMedMedlemskap())
+        `when`(client.tjenestepensjonsforhold(pid)).thenReturn(tjenestepensjonMedMedlemskap())
         val result = service.hentMedlemskapITjenestepensjonsordninger()
         assertEquals(listOf("Maritim pensjonskasse", "Statens pensjonskasse", "Kommunal Landspensjonskasse"), result)
     }
@@ -55,11 +55,11 @@ class TjenestepensjonServiceTest {
 
     private companion object {
         private fun tjenestepensjon() = Tjenestepensjon(forholdList = listOf(forhold()))
-        private fun tjenestepensjonMedMedlemskap() = Tjenestepensjon(
-            forholdList = listOf(
-                forhold("Maritim pensjonskasse"),
-                forhold("Statens pensjonskasse"),
-                forhold("Kommunal Landspensjonskasse")
+        private fun tjenestepensjonMedMedlemskap() = Tjenestepensjonsforhold(
+            tpOrdninger = listOf(
+                "Maritim pensjonskasse",
+                "Statens pensjonskasse",
+                "Kommunal Landspensjonskasse"
             )
         )
 

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/tp/TpTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/tp/TpTjenestepensjonClientTest.kt
@@ -78,6 +78,14 @@ class TpTjenestepensjonClientTest : WebClientTest() {
     }
 
     @Test
+    fun `'tjenestepensjon' gir forhold-liste naar personen har hatt tjenestepensjonsforhold`() {
+        arrange(okTjenestepensjonsforholdResponse())
+        val tjenestepensjonsforhold = client.tjenestepensjonsforhold(pid)
+
+       assertEquals(listOf("Utviklers pensjonskasse", "Pensjonskasse for folk flest"), tjenestepensjonsforhold.tpOrdninger)
+    }
+
+    @Test
     fun `'harTjenestepensjonsforhold' gir 'false' naar personen ikke har tjenestepensjonsforhold`() {
         arrange(okStatusResponse(false))
         assertFalse(client.harTjenestepensjonsforhold(pid, dato))
@@ -179,10 +187,88 @@ class TpTjenestepensjonClientTest : WebClientTest() {
     }
 }"""
 
+        private const val tjenestepensjonsForholdResponsBody = """
+            {
+  "fnr": "***********",
+  "forhold": [
+    {
+      "samtykkeSimulering": false,
+      "kilde": "PP01",
+      "tpNr": "3010",
+      "ordning": {
+        "navn": "Utviklers pensjonskasse",
+        "tpNr": "4",
+        "orgNr": "5",
+        "tssId": "6"
+      },
+      "harSimulering": false,
+      "harUtlandsPensjon": false,
+      "datoSamtykkeGitt": null,
+      "ytelser": [
+        {
+          "datoInnmeldtYtelseFom": "2020-01-01",
+          "ytelseType": "ALDER",
+          "datoYtelseIverksattFom": "2020-01-01",
+          "datoYtelseIverksattTom": "2020-12-31",
+          "changeStamp": {
+            "createdBy": "Dummy User",
+            "createdDate": "2022-09-20T13:30:00",
+            "updatedBy": "Dummy User",
+            "updatedDate": "2022-09-20T13:30:00"
+          }
+        }
+      ],
+      "changeStampDate": {
+        "createdBy": "Dummy User",
+        "createdDate": "2022-09-20T13:30:00",
+        "updatedBy": "Dummy User",
+        "updatedDate": "2022-09-20T13:30:00"
+      }
+    },
+    {
+      "samtykkeSimulering": false,
+      "kilde": "PP01",
+      "tpNr": "3010",
+      "ordning": {
+        "navn": "Pensjonskasse for folk flest",
+        "tpNr": "1",
+        "orgNr": "2",
+        "tssId": "3"
+      },
+      "harSimulering": false,
+      "harUtlandsPensjon": false,
+      "datoSamtykkeGitt": null,
+      "ytelser": [
+        {
+          "datoInnmeldtYtelseFom": "2020-01-01",
+          "ytelseType": "ALDER",
+          "datoYtelseIverksattFom": "2020-01-01",
+          "datoYtelseIverksattTom": "2020-12-31",
+          "changeStamp": {
+            "createdBy": "Dummy User",
+            "createdDate": "2022-09-20T13:30:00",
+            "updatedBy": "Dummy User",
+            "updatedDate": "2022-09-20T13:30:00"
+          }
+        }
+      ],
+      "changeStampDate": {
+        "createdBy": "Dummy User",
+        "createdDate": "2022-09-20T13:30:00",
+        "updatedBy": "Dummy User",
+        "updatedDate": "2022-09-20T13:30:00"
+      }
+    }
+  ]
+}
+        """
+
         private fun okApotekerResponse(value: Boolean) = jsonResponse().setBody(apotekerResponseBody(value).trimIndent())
 
         private fun okStatusResponse(value: Boolean) = jsonResponse().setBody(statusResponseBody(value).trimIndent())
 
         private fun okForholdResponse() = jsonResponse().setBody(forholdResponseBody().trimIndent())
+
+        private fun okTjenestepensjonsforholdResponse() = jsonResponse().setBody(tjenestepensjonsForholdResponsBody.trimIndent())
     }
 }


### PR DESCRIPTION
`api/tjenestepensjon` gir ikke navn på tp-ordning
`api/tjenestepensjon/finnTjenestepensjonsforhold` gjør det samme, men gir navn

Vi sanerer bruk av api/tjenestepensjon når frontend flyttes over det nye endepunktet