### PR TITLE
PEK-468 legg til mockede pensjonsavtaler fra test miljø

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -78,6 +78,7 @@ spec:
         - host: pensjon-pen-q2.dev-fss-pub.nais.io
         - host: pensjon-popp-q2.dev-fss-pub.nais.io
         - host: pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
+        - host: pensjon-testdata-facade.dev-fss-pub.nais.io # only in dev
         - host: pensjonskalkulator-unleash-api.nav.cloud.nais.io
         - host: pensjonssimulator.ekstern.dev.nav.no # only in dev
         - host: skjermede-personer-pip.intern.dev.nav.no
@@ -94,6 +95,8 @@ spec:
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
     - name: NORSK_PENSJON_URL
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
+    - name: NORSK_PENSJON_MOCK_URL
+      value: https://pensjon-testdata-facade.dev-fss-pub.nais.io # only in dev
     - name: PEN_SERVICE_ID
       value: dev-fss:pensjon-q2:pensjon-pen-q2
     - name: PEN_URL

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/avtale/PensjonsavtaleService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/avtale/PensjonsavtaleService.kt
@@ -1,23 +1,21 @@
 package no.nav.pensjon.kalkulator.avtale
 
 import no.nav.pensjon.kalkulator.avtale.client.PensjonsavtaleClient
-import no.nav.pensjon.kalkulator.general.Alder
-import no.nav.pensjon.kalkulator.general.Uttaksgrad
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidGetter
 import no.nav.pensjon.kalkulator.tech.toggle.FeatureToggleService
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 
 @Service
 class PensjonsavtaleService(
-    private val avtaleClient: PensjonsavtaleClient,
+    @Qualifier("norskPensjon") private val avtaleClient: PensjonsavtaleClient,
+    @Qualifier("norskPensjonMock") private val mockAvtaleClient: PensjonsavtaleClient,
     private val pidGetter: PidGetter,
     private val featureToggleService: FeatureToggleService
 ) {
     fun fetchAvtaler(spec: PensjonsavtaleSpec): Pensjonsavtaler {
-        val fnr = pidGetter.pid().value
-
-        return if (featureToggleService.isEnabled("mock-norsk-pensjon") && mockFnrs.contains(fnr))
-            mockPensjonsavtaler(fnr)
+        return if (featureToggleService.isEnabled("mock-norsk-pensjon"))
+            filter(mockAvtaleClient.fetchAvtaler(spec, pidGetter.pid()))
         else
             filter(avtaleClient.fetchAvtaler(spec, pidGetter.pid()))
     }
@@ -29,66 +27,5 @@ class PensjonsavtaleService(
                 avtaler = avtaler.avtaler.filter { it.kategori.included && it.harStartAar },
                 utilgjengeligeSelskap = avtaler.utilgjengeligeSelskap
             )
-
-        private val mockFnrs = listOf("46918903739", "02817996259")
-
-        /**
-         * Temporary function for testing pensjonsavtaler with specific characteristics
-         */
-        private fun mockPensjonsavtaler(fnr: String) =
-            if (fnr == "02817996259") mockGjensidigeAvtaler() else mockTidligeAvtaler()
-
-        /**
-         * Temporary function for testing pensjonsavtaler with start before uttaksalder
-         */
-        private fun mockTidligeAvtaler(): Pensjonsavtaler {
-            val startAlderAar = 57
-
-            return Pensjonsavtaler(
-                listOf(
-                    Pensjonsavtale(
-                        "Mock livsvarig individuell ordning",
-                        AvtaleKategori.INDIVIDUELL_ORDNING,
-                        startAlderAar,
-                        null,
-                        listOf(
-                            Utbetalingsperiode(
-                                startAlder = Alder(startAlderAar, 0),
-                                null,
-                                aarligUtbetaling = 32001,
-                                grad = Uttaksgrad.HUNDRE_PROSENT
-                            )
-                        )
-                    )
-                ), emptyList()
-            )
-        }
-
-        /**
-         * Temporary function for testing pensjonsavtaler with start/end maaneder not 0
-         */
-        private fun mockGjensidigeAvtaler(): Pensjonsavtaler {
-            val startAlderAar = 66
-            val startAlderMaaneder = 6
-
-            return Pensjonsavtaler(
-                listOf(
-                    Pensjonsavtale(
-                        "Mock privat tjenestepensjon",
-                        AvtaleKategori.PRIVAT_TJENESTEPENSJON,
-                        startAlderAar,
-                        null,
-                        listOf(
-                            Utbetalingsperiode(
-                                startAlder = Alder(startAlderAar, startAlderMaaneder),
-                                sluttAlder = Alder(startAlderAar + 10, startAlderMaaneder - 1), // NP bruker 'til', vi bruker 't.o.m.' => -1
-                                aarligUtbetaling = 29008,
-                                grad = Uttaksgrad.HUNDRE_PROSENT
-                            )
-                        )
-                    )
-                ), emptyList()
-            )
-        }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/v3/NorskPensjonMockPensjonsavtaleClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/v3/NorskPensjonMockPensjonsavtaleClient.kt
@@ -1,0 +1,67 @@
+package no.nav.pensjon.kalkulator.avtale.client.np.v3
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import no.nav.pensjon.kalkulator.avtale.client.np.v3.dto.NorskPensjonPensjonsavtaleSpecDto
+import no.nav.pensjon.kalkulator.tech.security.egress.token.saml.SamlTokenService
+import no.nav.pensjon.kalkulator.tech.trace.TraceAid
+import no.nav.pensjon.kalkulator.tech.web.CustomHttpHeaders
+import no.nav.pensjon.kalkulator.tech.web.EgressException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+/**
+ * Denne klienten skal hente mockede pensjonsavtaler i dev
+ */
+@Component("norskPensjonMock")
+class NorskPensjonMockPensjonsavtaleClient(
+    @Value("\${norsk.pensjon.mock.url}") mockUrl: String,
+    tokenGetter: SamlTokenService,
+    webClientBuilder: WebClient.Builder,
+    val traceAid: TraceAid,
+    xmlMapper: XmlMapper,
+    @Value("\${web-client.retry-attempts}") retryAttempts: String,
+) : NorskPensjonPensjonsavtaleClient(
+    baseUrl = mockUrl,
+    tokenGetter = tokenGetter,
+    webClientBuilder = webClientBuilder,
+    xmlMapper = xmlMapper,
+    traceAid = traceAid,
+    retryAttempts = retryAttempts
+) {
+
+    override fun fetchAvtalerXml(spec: NorskPensjonPensjonsavtaleSpecDto): String {
+        val uri = "/api/v1/pensjonsavtale"
+        val callId = traceAid.callId()
+        val body = soapEnvelope(soapBody(spec, callId))
+
+        try {
+            return webClient
+                .post()
+                .uri(uri)
+                .headers {
+                    it[HttpHeaders.CONTENT_TYPE] = MediaType.APPLICATION_XML_VALUE
+                    it[CustomHttpHeaders.CALL_ID] = callId
+                }
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String::class.java)
+                .retryWhen(retryBackoffSpec(uri))
+                .block()
+                ?: ""
+        } catch (e: WebClientRequestException) {
+            throw EgressException("Failed calling $uri", e)
+        } catch (e: WebClientResponseException) {
+            throw EgressException(e.responseBodyAsString, e)
+        }
+    }
+
+    override fun soapHeader() =
+        """<S:Header>
+    </S:Header>"""
+
+}

--- a/src/main/resources/application-local-ps.properties
+++ b/src/main/resources/application-local-ps.properties
@@ -1,3 +1,4 @@
 # For testing with local pensjonssimulator:
 logging.level.reactor.netty.http.client=DEBUG
 pensjonssimulator.url=http://localhost:8081
+norsk.pensjon.mock.url=https://pensjon-testdata-facade.intern.dev.nav.no

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -8,3 +8,4 @@ pensjon-regler.url=${PENSJON_REGLER_URL:https://pensjon-regler-q2.dev.intern.nav
 nais.app.name=${NAIS_APP_NAME:pensjonskalkulator-backend}
 nais.cluster.name=${NAIS_CLUSTER_NAME:dev-gcp}
 unleash.server.api.url=${UNLEASH_SERVER_API_URL:https://pensjonskalkulator-unleash-api.nav.cloud.nais.io}
+norsk.pensjon.mock.url=https://pensjon-testdata-facade.intern.dev.nav.no

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,6 +37,7 @@ pensjon-regler.service-id=${PENSJON_REGLER_SERVICE_ID:...}
 pensjon-regler.url=${proxy.url}
 pensjonssimulator.service-id=nav:pensjonssimulator:simulering
 pensjonssimulator.url=https://pensjonssimulator.ekstern.dev.nav.no
+norsk.pensjon.mock.url=${NORSK_PENSJON_MOCK_URL:https://skal-kalles-kun-i-dev}
 persondata.service-id=${PERSONDATA_SERVICE_ID:dev-fss:pdl:pdl-api}
 persondata.url=${PERSONDATA_URL:https://pdl-api.dev.intern.nav.no}
 popp.service-id=${POPP_SERVICE_ID:dev-fss:pensjonopptjening:pensjon-popp-q2}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/v3/NorskPensjonMockPensjonsavtaleClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/v3/NorskPensjonMockPensjonsavtaleClientTest.kt
@@ -1,0 +1,106 @@
+package no.nav.pensjon.kalkulator.avtale.client.np.v3
+
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.kalkulator.avtale.client.np.v3.NorskPensjonPensjonsavtaleClientTest.Companion.EN_AVTALE_RESPONSE_BODY
+import no.nav.pensjon.kalkulator.avtale.client.np.v3.NorskPensjonPensjonsavtaleClientTest.Companion.assertRequestBody
+import no.nav.pensjon.kalkulator.avtale.client.np.v3.NorskPensjonPensjonsavtaleClientTest.Companion.okResponse
+import no.nav.pensjon.kalkulator.avtale.client.np.v3.NorskPensjonPensjonsavtaleClientTest.Companion.spec
+import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration.Companion.arrangeSecurityContext
+import no.nav.pensjon.kalkulator.mock.PensjonsavtaleFactory.avtaleMedToUtbetalingsperioder
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.mock.WebClientTest
+import no.nav.pensjon.kalkulator.mock.XmlMapperFactory.xmlMapper
+import no.nav.pensjon.kalkulator.tech.security.egress.token.saml.SamlTokenService
+import no.nav.pensjon.kalkulator.tech.security.egress.token.saml.SamlTokenServiceTest.Companion.SAML_ASSERTION
+import no.nav.pensjon.kalkulator.tech.trace.TraceAid
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+import org.springframework.web.reactive.function.client.WebClient
+
+@SpringBootTest
+@TestPropertySource("classpath:application-test.properties")
+class NorskPensjonMockPensjonsavtaleClientTest : WebClientTest() {
+
+    private lateinit var client: NorskPensjonMockPensjonsavtaleClient
+
+    @Mock
+    private lateinit var tokenService: SamlTokenService
+
+    @Mock
+    private lateinit var traceAid: TraceAid
+
+    @Autowired
+    private lateinit var webClientBuilder: WebClient.Builder
+
+    @BeforeEach
+    fun initialize() {
+        `when`(tokenService.assertion()).thenReturn(SAML_ASSERTION)
+        `when`(traceAid.callId()).thenReturn("id1")
+        arrangeSecurityContext()
+
+        client = NorskPensjonMockPensjonsavtaleClient(
+            mockUrl = baseUrl(),
+            tokenGetter = tokenService,
+            webClientBuilder = webClientBuilder,
+            xmlMapper = xmlMapper(),
+            traceAid = traceAid,
+            retryAttempts = "1"
+        )
+    }
+
+    @Test
+    fun `fetchAvtaler handles 1 avtale with 2 utbetalingsperioder & request has a Header without SAML`() {
+        arrange(okResponse(EN_AVTALE_RESPONSE_BODY))
+
+        val avtaler = client.fetchAvtaler(spec(), pid).avtaler
+
+        assertRequestBody(EXPECTED_REQUEST_BODY)
+        assertEquals(1, avtaler.size)
+        avtaler[0] shouldBe avtaleMedToUtbetalingsperioder()
+    }
+
+    companion object {
+
+        @Language("xml")
+        private const val EXPECTED_REQUEST_BODY = """<?xml version="1.0" ?>
+<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:typ="http://norskpensjon.no/api/pensjonskalkulator/v3/typer">
+    <S:Header>
+    </S:Header>
+    <S:Body>
+        <typ:kalkulatorForespoersel>
+            <userSessionCorrelationID>id1</userSessionCorrelationID>
+            <organisasjonsnummer>889640782</organisasjonsnummer>
+            <rettighetshaver>
+                <foedselsnummer>12906498357</foedselsnummer>
+                <aarligInntektFoerUttak>123000</aarligInntektFoerUttak>
+                <uttaksperiode>
+                    <startAlder>63</startAlder>
+                    <startMaaned>2</startMaaned>
+                    <grad>80</grad>
+                    <aarligInntekt>100000</aarligInntekt>
+                </uttaksperiode><uttaksperiode>
+                    <startAlder>64</startAlder>
+                    <startMaaned>3</startMaaned>
+                    <grad>100</grad>
+                    <aarligInntekt>200000</aarligInntekt>
+                </uttaksperiode>
+                <antallInntektsaarEtterUttak>13</antallInntektsaarEtterUttak>
+                <harAfp>false</harAfp>
+                <antallAarIUtlandetEtter16>0</antallAarIUtlandetEtter16>
+                <sivilstatus>gift</sivilstatus>
+                <harEpsPensjon>true</harEpsPensjon>
+                <harEpsPensjonsgivendeInntektOver2G>true</harEpsPensjonsgivendeInntektOver2G>
+                <oenskesSimuleringAvFolketrygd>false</oenskesSimuleringAvFolketrygd>
+            </rettighetshaver>
+        </typ:kalkulatorForespoersel>
+    </S:Body>
+</S:Envelope>"""
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/v3/NorskPensjonPensjonsavtaleClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/client/np/v3/NorskPensjonPensjonsavtaleClientTest.kt
@@ -27,7 +27,6 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.web.reactive.function.client.WebClient
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
-import java.util.*
 
 @SpringBootTest
 @TestPropertySource("classpath:application-test.properties")
@@ -66,7 +65,7 @@ class NorskPensjonPensjonsavtaleClientTest : WebClientTest() {
 
         val avtaler = client.fetchAvtaler(spec(), pid).avtaler
 
-        assertRequestBody()
+        assertRequestBody(EXPECTED_REQUEST_BODY)
         assertEquals(1, avtaler.size)
         avtaler[0] shouldBe avtaleMedToUtbetalingsperioder()
     }
@@ -204,7 +203,7 @@ class NorskPensjonPensjonsavtaleClientTest : WebClientTest() {
 </soap:Envelope>"""
 
         @Language("xml")
-        private const val EN_AVTALE_RESPONSE_BODY =
+        const val EN_AVTALE_RESPONSE_BODY =
             """<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Header/>
     <soap:Body wsu:Id="x" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
@@ -375,9 +374,9 @@ class NorskPensjonPensjonsavtaleClientTest : WebClientTest() {
     </soap:Body>
 </soap:Envelope>"""
 
-        private fun okResponse(avtale: String) = jsonResponse(HttpStatus.OK).setBody(avtale)
+        fun okResponse(avtale: String) = jsonResponse(HttpStatus.OK).setBody(avtale)
 
-        private fun spec() =
+        fun spec() =
             PensjonsavtaleSpec(
                 aarligInntektFoerUttak = 123000,
                 uttaksperioder = listOf(uttaksperiodeSpec(1), uttaksperiodeSpec(2)),
@@ -478,11 +477,11 @@ class NorskPensjonPensjonsavtaleClientTest : WebClientTest() {
                 grad = Uttaksgrad.AATTI_PROSENT
             )
 
-        private fun assertRequestBody() {
+        fun assertRequestBody(body: String) {
             ByteArrayOutputStream().use {
                 val request = takeRequest()
                 request.body.copyTo(it)
-                assertEquals(EXPECTED_REQUEST_BODY, it.toString(StandardCharsets.UTF_8))
+                assertEquals(body, it.toString(StandardCharsets.UTF_8))
             }
         }
     }


### PR DESCRIPTION
Pensjonsavtalene lagres og hentes fra pensjon-testdata-facade:
[https://pensjon-testdata-facade.dev-fss-pub.nais.io/swagger-ui/index.html#/Pensjonsavtale/hentPensjonsavtaler](https://pensjon-testdata-facade.dev-fss-pub.nais.io/swagger-ui/index.html#/Pensjonsavtale/hentPensjonsavtaler)

Det utføres ingen simulering/beregning, kun henting av det som var lagret på forhånd.

Lagrede avtaler hentes, hvis feature toggle er aktivert: 
[https://pensjonskalkulator-unleash-web.iap.nav.cloud.nais.io/projects/default/features/mock-norsk-pensjon
](https://pensjonskalkulator-unleash-web.iap.nav.cloud.nais.io/projects/default/features/mock-norsk-pensjon
)