### PR TITLE
raise line length limits for better code readability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[{*.gradle.kts,*.kt,*.kts,*.main.kts,*.space.kts}]
+max_line_length = 1500


### PR DESCRIPTION
Ville øke antall symboler per kodelinje i tilfeller, når det trengs slik at IntelliJ lar dem stå.
Noen tanker?