### PR TITLE
PEK-486 oppdater etterlatte-api appnavnet og ta i bruk service discovery

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -70,7 +70,7 @@ spec:
         - application: tp-q2
           namespace: pensjonsamhandling
           cluster: dev-fss
-        - application: etterlatte-samordning-vedtak
+        - application: etterlatte-api
           namespace: etterlatte
           cluster: dev-gcp
       external:
@@ -122,9 +122,9 @@ spec:
     - name: TJENESTEPENSJON_URL
       value: https://tp-api-q2.dev-fss-pub.nais.io
     - name: OMSTILLINGSSTOENAD_SERVICE_ID
-      value: dev-gcp:etterlatte:etterlatte-samordning-vedtak
+      value: dev-gcp:etterlatte:etterlatte-api
     - name: OMSTILLINGSSTOENAD_SERVICE_URL
-      value: https://etterlatte-samordning-vedtak.intern.dev.nav.no
+      value: http://etterlatte-api.etterlatte
     - name: PKB_FRONTEND_ENTRA_CLIENT_ID
       value: 0683a6ca-6f72-458c-8367-2879103edbfc,66a20121-b743-48e5-8cdc-1037ce68d9a5,6d1669ef-61c4-4d14-98a7-0c983f4eb14a
     - name: SERVER_ERROR_INCLUDE_STACKTRACE

--- a/.nais/deploy-prod.yml
+++ b/.nais/deploy-prod.yml
@@ -62,7 +62,7 @@ spec:
         - application: tp
           namespace: pensjonsamhandling
           cluster: prod-fss
-        - application: etterlatte-samordning-vedtak
+        - application: etterlatte-api
           namespace: etterlatte
           cluster: prod-gcp
       external:
@@ -110,9 +110,9 @@ spec:
     - name: TJENESTEPENSJON_URL
       value: https://tp-api.prod-fss-pub.nais.io
     - name: OMSTILLINGSSTOENAD_SERVICE_ID
-      value: prod-gcp:etterlatte:etterlatte-samordning-vedtak
+      value: prod-gcp:etterlatte:etterlatte-api
     - name: OMSTILLINGSSTOENAD_SERVICE_URL
-      value: https://etterlatte-samordning-vedtak.intern.nav.no
+      value: http://etterlatte-api.etterlatte
     - name: PKB_FRONTEND_ENTRA_CLIENT_ID
       value: irrelevant-when-obo-token-used
     - name: PKB_GROUP_ID_SAKSBEHANDLER

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,8 +29,8 @@ proxy.url=${FSS_GATEWAY_URL:https://pensjon-selvbetjening-fss-gateway.dev.intern
 
 idporten.ping.url=${IDPORTEN_PING_URL:https://test.idporten.no/.well-known/openid-configuration}
 norsk-pensjon.url=${proxy.url}
-omstillingsstoenad-service-id=${OMSTILLINGSSTOENAD_SERVICE_ID:dev-gcp:etterlatte:etterlatte-samordning-vedtak}
-omstillingsstoenad.url=${OMSTILLINGSSTOENAD_SERVICE_URL:https://etterlatte-samordning-vedtak.intern.dev.nav.no}
+omstillingsstoenad-service-id=${OMSTILLINGSSTOENAD_SERVICE_ID:dev-gcp:etterlatte:etterlatte-api}
+omstillingsstoenad.url=${OMSTILLINGSSTOENAD_SERVICE_URL:https://etterlatte-api.intern.dev.nav.no}
 pen.service-id=${PEN_SERVICE_ID:dev-fss:pensjon-q2:pensjon-pen-q2}
 pen.url=${PEN_URL:https://pensjon-pen-q2.dev.adeo.no}
 pensjon-regler.service-id=${PENSJON_REGLER_SERVICE_ID:...}


### PR DESCRIPTION
Etterlatte endrer navnet til appen sin. Med [service discovery](https://docs.nais.io/workloads/how-to/communication/) slipper man å gå via ingresser og forhåpentligvis slippe nettverksproblemer pga det.

[https://github.com/navikt/pensjon-etterlatte-saksbehandling/blob/main/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml](https://github.com/navikt/pensjon-etterlatte-saksbehandling/blob/main/apps/etterlatte-samordning-vedtak/.nais/prod-api.yaml)