### PR TITLE
unngå TOOMANYREQUESTS fra trivy mot OCI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,6 +96,8 @@ jobs:
     name: Scan Docker image
     needs: [ build ]
     if: github.ref == 'refs/heads/main'
+    env:
+      TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
Det anbefales til å spesifisere truvy-db url for å unngå `TOOMANYREQUESTS` ved image scan
[https://nav-it.slack.com/archives/C5KUST8N6/p1730118311599129](https://nav-it.slack.com/archives/C5KUST8N6/p1730118311599129)