### PR TITLE
MockBean -> MockitoBean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,10 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <kotlin.code.style>official</kotlin.code.style>
+        <kotlin.compiler.apiVersion>2.0</kotlin.compiler.apiVersion>
+        <kotlin.compiler.languageVersion>2.0</kotlin.compiler.languageVersion>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
-        <kotlin.version>2.0.21</kotlin.version>
+        <kotlin.version>2.1.0</kotlin.version>
         <logback.version>1.5.12</logback.version>
         <okhttp3.version>4.12.0</okhttp3.version>
     </properties>
@@ -152,7 +154,7 @@
         <dependency>
             <groupId>io.getunleash</groupId>
             <artifactId>unleash-client-java</artifactId>
-            <version>9.2.5</version>
+            <version>9.2.6</version>
         </dependency>
         <dependency>
             <groupId>io.github.microutils</groupId>

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/api/AnsattControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/api/AnsattControllerTest.kt
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -24,19 +24,19 @@ class AnsattControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: AnsattService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/api/PensjonsavtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/api/PensjonsavtaleControllerTest.kt
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -29,19 +29,19 @@ class PensjonsavtaleControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var avtaleService: PensjonsavtaleService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingControllerTest.kt
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -29,19 +29,19 @@ class EkskluderingControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: EkskluderingFacade
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/omstillingsstoenad/api/OmstillingsstoenadOgGjenlevendeYtelseControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/omstillingsstoenad/api/OmstillingsstoenadOgGjenlevendeYtelseControllerTest.kt
@@ -9,21 +9,16 @@ import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMem
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
-import org.springframework.http.MediaType
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @ExtendWith(SpringExtension::class)
@@ -34,19 +29,19 @@ class OmstillingsstoenadOgGjenlevendeYtelseControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: OmstillingOgGjenlevendeYtelseService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/InntektControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/InntektControllerTest.kt
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -30,19 +30,19 @@ class InntektControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: InntektService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/api/PersonControllerTest.kt
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
@@ -26,19 +26,19 @@ class PersonControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: PersonService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
@@ -16,11 +16,11 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -34,25 +34,25 @@ class SimuleringControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var simuleringService: SimuleringService
 
-    @MockBean
+    @MockitoBean
     private lateinit var anonymSimuleringService: AnonymSimuleringService
 
-    @MockBean
+    @MockitoBean
     private lateinit var feature: FeatureToggleService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test
@@ -116,7 +116,7 @@ class SimuleringControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(responseBodyV7MedAFPOffentlig()))
+            .andExpect(content().json(responseBodyV7MedAfpOffentlig()))
     }
 
     @Test
@@ -305,11 +305,10 @@ class SimuleringControllerTest {
                   "alder": 67
                 }
               ]
-            }
-        }""".trimIndent()
+            }""".trimIndent()
 
         @Language("json")
-        private fun responseBodyV7MedAFPOffentlig() = """{
+        private fun responseBodyV7MedAfpOffentlig() = """{
             "alderspensjon": [
               {
                 "beloep": $PENSJONSBELOEP,

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/crypto/api/CryptoControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/crypto/api/CryptoControllerTest.kt
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -26,19 +26,19 @@ class CryptoControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidEncryptionService: PidEncryptionService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/status/StatusControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/status/StatusControllerTest.kt
@@ -8,10 +8,10 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -24,13 +24,13 @@ class StatusControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/toggle/api/FeatureToggleControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/toggle/api/FeatureToggleControllerTest.kt
@@ -6,13 +6,12 @@ import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.toggle.FeatureToggleService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -24,19 +23,19 @@ class FeatureToggleControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var featureToggleService: FeatureToggleService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/api/TjenestepensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/api/TjenestepensjonControllerTest.kt
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -27,19 +27,19 @@ class TjenestepensjonControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var tjenestepensjonService: TjenestepensjonService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ufoere/api/UfoerepensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ufoere/api/UfoerepensjonControllerTest.kt
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -29,19 +29,19 @@ class UfoerepensjonControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var ufoeretrygdService: UfoerepensjonService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/UttaksalderControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/UttaksalderControllerTest.kt
@@ -4,8 +4,8 @@ import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.land.Land
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.person.Sivilstand
-import no.nav.pensjon.kalkulator.simulering.SimuleringType
 import no.nav.pensjon.kalkulator.simulering.Opphold
+import no.nav.pensjon.kalkulator.simulering.SimuleringType
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
@@ -17,10 +17,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -34,19 +34,19 @@ internal class UttaksalderControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var uttaksalderService: UttaksalderService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/api/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/api/VedtakControllerTest.kt
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -29,22 +29,22 @@ class VedtakControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     private lateinit var loependeVedtakService: LoependeVedtakService
 
-    @MockBean
+    @MockitoBean
     private lateinit var service: VedtakMedUtbetalingService
 
-    @MockBean
+    @MockitoBean
     private lateinit var traceAid: TraceAid
 
-    @MockBean
+    @MockitoBean
     private lateinit var pidExtractor: PidExtractor
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService
 
-    @MockBean
+    @MockitoBean
     private lateinit var auditor: Auditor
 
     @Test


### PR DESCRIPTION
Erstatter `@MockBean`, som er _deprecated_ (ref . [Spring doc](https://docs.spring.io/spring-boot/api/java/org/springframework/boot/test/mock/mockito/MockBean.html)).

Bumper Kotlin og Unleash.

Angir også `kotlin.compiler.languageVersion` + `kotlin.compiler.apiVersion` (ref.  [PEN PR](https://github.com/navikt/pensjon-pen/pull/14366)).