### PR TITLE
PEK-829 Use POST in call to 'skjermet'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>no.nav.pensjon</groupId>
     <artifactId>pensjonskalkulator-backend</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <name>pensjonskalkulator-backend</name>
     <description>Backend for pensjonskalkulator for brukere født 1963 eller senere</description>
     <packaging>jar</packaging>

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
@@ -20,7 +20,7 @@ class OpenApiConfiguration {
                 Info()
                     .title("pensjonskalkulator API")
                     .description("Pensjonskalkulator for brukere født i 1963 eller senere")
-                    .version("v1.5.0")
+                    .version("v1.5.1")
             )
             .externalDocs(
                 ExternalDocumentation()
@@ -37,6 +37,7 @@ class OpenApiConfiguration {
                 "/api/v7/alderspensjon/simulering",
                 "/api/v6/alderspensjon/simulering",
                 "/api/v1/alderspensjon/anonym-simulering",
+                "/api/v3/pensjonsavtaler",
                 "/api/v2/pensjonsavtaler",
                 "/api/v1/loepende-omstillingsstoenad-eller-gjenlevendeytelse",
                 "/api/v2/vedtak/loepende-vedtak",

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/skjerming/client/nom/NomSkjermingSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/skjerming/client/nom/NomSkjermingSpec.kt
@@ -1,0 +1,6 @@
+package no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.skjerming.client.nom
+
+/**
+ * NOM = Nav organisasjonsmaster
+ */
+data class NomSkjermingSpec(val personident: String)


### PR DESCRIPTION
Endring 1: Bruker POST i kall til 'skjermet' (se [Slack-melding](https://nav-it.slack.com/archives/CTN3BDUQ2/p1730286270363839) for bakgrunn).

Endring 2: Legger til `/api/v3/pensjonsavtaler` i API-dok (glemte dette i [PR 140](https://github.com/navikt/pensjonskalkulator-backend/pull/140)).