### PR TITLE
Fremtidige inntekter i tjenestepensjon-simulering

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -72,6 +72,10 @@ spec:
         - application: pensjonskalkulator-uinnlogget-dreambox
         - application: pensjonskalkulator-uinnlogget-magicbox
         - application: pensjonskalkulator-uinnlogget-sandbox
+        - application: pensjonskalkulator-frontend-coffeebox
+        - application: pensjonskalkulator-veiledning-frontend-coffeebox
+        - application: pensjonskalkulator-frontend-codebox
+        - application: pensjonskalkulator-veiledning-frontend-codebox
         - application: azure-token-generator # only in dev
           namespace: aura
         - application: wonderwalled-idporten # only in dev

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
@@ -59,6 +59,7 @@ class OpenApiConfiguration {
                 "/api/tpo-medlemskap",
                 "/api/v1/tpo-medlemskap",
                 "/api/v1/simuler-oftp",
+                "/api/v2/simuler-oftp",
                 "/api/status",
             )
             .build()

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringService.kt
@@ -4,6 +4,7 @@ import no.nav.pensjon.kalkulator.tech.security.ingress.PidGetter
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.TjenestepensjonSimuleringClient
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.OffentligTjenestepensjonSimuleringsresultat
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.SimuleringOffentligTjenestepensjonSpec
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.SimuleringOffentligTjenestepensjonSpecV2
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,6 +14,11 @@ class TjenestepensjonSimuleringService(
 ) {
 
     fun hentTjenestepensjonSimulering(request: SimuleringOffentligTjenestepensjonSpec): OffentligTjenestepensjonSimuleringsresultat {
+        val pid = pidGetter.pid()
+        return tjenestepensjonSimuleringClient.hentTjenestepensjonSimulering(request, pid)
+    }
+
+    fun hentTjenestepensjonSimuleringV2(request: SimuleringOffentligTjenestepensjonSpecV2): OffentligTjenestepensjonSimuleringsresultat {
         val pid = pidGetter.pid()
         return tjenestepensjonSimuleringClient.hentTjenestepensjonSimulering(request, pid)
     }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/TjenestepensjonSimuleringController.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/TjenestepensjonSimuleringController.kt
@@ -6,11 +6,14 @@ import no.nav.pensjon.kalkulator.common.api.ControllerBase
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.tech.web.EgressException
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.TjenestepensjonSimuleringService
-import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.*
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.IngressSimuleringOffentligTjenestepensjonSpecV1
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.IngressSimuleringOffentligTjenestepensjonSpecV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.OffentligTjenestepensjonSimuleringsresultatDtoV1
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.OffentligTjenestepensjonSimuleringsresultatDtoV2
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringResultMapperV1
-import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringResultMapperV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringResultMapperV2.toDtoV2
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringSpecMapperV1.fromDto
-import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringSpecMapperV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringSpecMapperV2.fromDtoV2
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -54,7 +57,7 @@ class TjenestepensjonSimuleringController(
         log.debug { "Request for simuler Offentlig tjenestepensjon V2" }
 
         return try {
-            TjenestepensjonSimuleringResultMapperV2.toDto(timed(service::hentTjenestepensjonSimulering, TjenestepensjonSimuleringSpecMapperV2.fromDto(spec), "simulerOffentligTjenestepensjon"))
+            toDtoV2(timed(service::hentTjenestepensjonSimuleringV2, fromDtoV2(spec), "simulerOffentligTjenestepensjon"))
                 .also { log.debug { "Simuler Offentlig tjenestepensjon respons: $it" } }
         } catch (e: EgressException) {
             handleError(e, "V2")!!

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/TjenestepensjonSimuleringController.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/TjenestepensjonSimuleringController.kt
@@ -8,7 +8,9 @@ import no.nav.pensjon.kalkulator.tech.web.EgressException
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.TjenestepensjonSimuleringService
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.*
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringResultMapperV1
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringResultMapperV2
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringSpecMapperV1.fromDto
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map.TjenestepensjonSimuleringSpecMapperV2
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -37,6 +39,25 @@ class TjenestepensjonSimuleringController(
                 .also { log.debug { "Simuler Offentlig tjenestepensjon respons: $it" } }
         } catch (e: EgressException) {
             handleError(e, "V1")!!
+        } finally {
+            traceAid.end()
+        }
+    }
+
+    @PostMapping("v2/simuler-oftp")
+    @Operation(
+        summary = "Simuler offentlig tjenestepensjon hos tp-leverandør bruker er medlem av",
+        description = "Simulerer offentlig tjenestepensjon hos tp-leverandør som har ansvar for brukers tjenestepensjon"
+    )
+    fun simulerOffentligTjenestepensjonV2(@RequestBody spec: IngressSimuleringOffentligTjenestepensjonSpecV2): OffentligTjenestepensjonSimuleringsresultatDtoV2 {
+        traceAid.begin()
+        log.debug { "Request for simuler Offentlig tjenestepensjon V2" }
+
+        return try {
+            TjenestepensjonSimuleringResultMapperV2.toDto(timed(service::hentTjenestepensjonSimulering, TjenestepensjonSimuleringSpecMapperV2.fromDto(spec), "simulerOffentligTjenestepensjon"))
+                .also { log.debug { "Simuler Offentlig tjenestepensjon respons: $it" } }
+        } catch (e: EgressException) {
+            handleError(e, "V2")!!
         } finally {
             traceAid.end()
         }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/dto/IngressSimuleringOffentligTjenestepensjonSpecV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/dto/IngressSimuleringOffentligTjenestepensjonSpecV2.kt
@@ -1,0 +1,41 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto
+
+import java.time.LocalDate
+
+data class IngressSimuleringOffentligTjenestepensjonSpecV2 (
+    val foedselsdato: LocalDate,
+    val aarligInntektFoerUttakBeloep: Int,
+    val gradertUttak: SimuleringOffentligTjenestepensjonGradertUttakV2?,
+    val heltUttak: SimuleringOffentligTjenestepensjonHeltUttakV2,
+    val utenlandsperiodeListe: List<UtenlandsoppholdV2> = emptyList(),
+    val epsHarPensjon: Boolean,
+    val epsHarInntektOver2G: Boolean,
+    val brukerBaOmAfp: Boolean,
+)
+
+data class UtenlandsoppholdV2 (
+    val fom: LocalDate,
+    val tom: LocalDate?
+)
+
+data class SimuleringOffentligTjenestepensjonGradertUttakV2(
+    val uttaksalder: SimuleringOffentligTjenestepensjonAlderV2,
+    val aarligInntektVsaPensjonBeloep: Int?
+)
+
+data class SimuleringOffentligTjenestepensjonHeltUttakV2(
+    val uttaksalder: SimuleringOffentligTjenestepensjonAlderV2,
+    val aarligInntektVsaPensjon: SimuleringOffentligTjenestepensjonInntektV2?
+)
+
+data class SimuleringOffentligTjenestepensjonInntektV2(
+    val beloep: Int,
+    val sluttAlder: SimuleringOffentligTjenestepensjonAlderV2
+)
+
+data class SimuleringOffentligTjenestepensjonAlderV2(val aar: Int, val maaneder: Int) {
+    init {
+        require(aar in 0..200) { "0 <= aar <= 200" }
+        require(maaneder in 0..11) { "0 <= maaneder <= 11" }
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/dto/OffentligTjenestepensjonSimuleringsresultatDtoV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/dto/OffentligTjenestepensjonSimuleringsresultatDtoV2.kt
@@ -1,0 +1,41 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import no.nav.pensjon.kalkulator.general.Alder
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.ResultatType
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OffentligTjenestepensjonSimuleringsresultatDtoV2 (
+    val simuleringsresultatStatus: SimuleringsresultatStatusV2 = SimuleringsresultatStatusV2.OK,
+    val muligeTpLeverandoerListe: List<String> = emptyList(),
+    val simulertTjenestepensjon: SimulertTjenestepensjonV2? = null,
+)
+
+enum class SimuleringsresultatStatusV2(val resultatType: ResultatType?) {
+    OK(ResultatType.OK),
+    BRUKER_ER_IKKE_MEDLEM_AV_TP_ORDNING(ResultatType.IKKE_MEDLEM),
+    TP_ORDNING_STOETTES_IKKE(ResultatType.TP_ORDNING_STOETTES_IKKE),
+    TOM_SIMULERING_FRA_TP_ORDNING(ResultatType.TOM_RESPONS),
+    TEKNISK_FEIL(null);
+
+    companion object {
+        fun fromResultatType(resultatType: ResultatType) = entries.firstOrNull { it.resultatType == resultatType } ?: TEKNISK_FEIL
+    }
+}
+
+data class SimulertTjenestepensjonV2(
+    val tpLeverandoer: String,
+    val simuleringsresultat: SimuleringsresultatV2
+)
+
+data class SimuleringsresultatV2(
+    val utbetalingsperioder: List<UtbetalingsperiodeV2>,
+    val betingetTjenestepensjonErInkludert: Boolean = false
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class UtbetalingsperiodeV2(
+    val startAlder: Alder,
+    val sluttAlder: Alder?,
+    val aarligUtbetaling: Int,
+)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2.kt
@@ -1,0 +1,23 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map
+
+import no.nav.pensjon.kalkulator.tech.time.DateUtil.MAANEDER_PER_AAR
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.*
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.OffentligTjenestepensjonSimuleringsresultat
+
+object TjenestepensjonSimuleringResultMapperV2 {
+
+    fun toDto(simuleringsresultat: OffentligTjenestepensjonSimuleringsresultat) = OffentligTjenestepensjonSimuleringsresultatDtoV2(
+        simuleringsresultatStatus = SimuleringsresultatStatusV2.fromResultatType(simuleringsresultat.simuleringsResultatStatus.resultatType),
+        muligeTpLeverandoerListe = simuleringsresultat.tpOrdninger,
+        simulertTjenestepensjon = simuleringsresultat.simuleringsResultat?.let {
+            SimulertTjenestepensjonV2(
+                tpLeverandoer = it.tpOrdning,
+                simuleringsresultat = SimuleringsresultatV2(
+                    utbetalingsperioder = it.perioder
+                        .map { utbetaling -> UtbetalingsperiodeV2(utbetaling.startAlder, utbetaling.sluttAlder, utbetaling.maanedligBeloep * MAANEDER_PER_AAR) },
+                    betingetTjenestepensjonErInkludert = it.betingetTjenestepensjonInkludert,
+                )
+            )
+        },
+    )
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2.kt
@@ -6,7 +6,7 @@ import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.O
 
 object TjenestepensjonSimuleringResultMapperV2 {
 
-    fun toDto(simuleringsresultat: OffentligTjenestepensjonSimuleringsresultat) = OffentligTjenestepensjonSimuleringsresultatDtoV2(
+    fun toDtoV2(simuleringsresultat: OffentligTjenestepensjonSimuleringsresultat) = OffentligTjenestepensjonSimuleringsresultatDtoV2(
         simuleringsresultatStatus = SimuleringsresultatStatusV2.fromResultatType(simuleringsresultat.simuleringsResultatStatus.resultatType),
         muligeTpLeverandoerListe = simuleringsresultat.tpOrdninger,
         simulertTjenestepensjon = simuleringsresultat.simuleringsResultat?.let {

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringSpecMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringSpecMapperV2.kt
@@ -1,0 +1,67 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map
+
+import no.nav.pensjon.kalkulator.general.Alder
+import no.nav.pensjon.kalkulator.simulering.PensjonUtil.uttakDato
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.IngressSimuleringOffentligTjenestepensjonSpecV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.UtenlandsoppholdV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.SimuleringOffentligTjenestepensjonSpec
+import java.time.LocalDate
+
+object TjenestepensjonSimuleringSpecMapperV2 {
+
+    fun fromDto(spec: IngressSimuleringOffentligTjenestepensjonSpecV2): SimuleringOffentligTjenestepensjonSpec {
+        return SimuleringOffentligTjenestepensjonSpec(
+            foedselsdato = spec.foedselsdato,
+            uttaksdato = uttakDato(spec.foedselsdato, mapToUttaksalder(spec)),
+            sisteInntekt = spec.aarligInntektFoerUttakBeloep,
+            aarIUtlandetEtter16 = antallAar(spec.utenlandsperiodeListe),
+            brukerBaOmAfp = spec.brukerBaOmAfp,
+            epsPensjon = spec.epsHarPensjon,
+            eps2G = spec.epsHarInntektOver2G
+        )
+    }
+
+    private fun mapToUttaksalder(spec: IngressSimuleringOffentligTjenestepensjonSpecV2): Alder {
+        return (spec.gradertUttak?.uttaksalder ?: spec.heltUttak.uttaksalder)
+            .let { Alder(it.aar, it.maaneder) }
+    }
+
+    private fun antallAar(oppholdListe: List<UtenlandsoppholdV2>): Int {
+        val sammenslattePerioder = slaaSammenOverlappendePerioder(oppholdListe)
+        val antallDager = antallDager(sammenslattePerioder)
+        return (antallDager / DAGER_PER_AAR).toInt()
+    }
+
+    private fun antallDager(oppholdListe: List<UtenlandsoppholdV2>): Long {
+        return oppholdListe.sumOf { (it.tom ?: LocalDate.now()).toEpochDay() + 1 - it.fom.toEpochDay() }
+    }
+
+    private fun slaaSammenOverlappendePerioder(oppholdListe: List<UtenlandsoppholdV2>): List<UtenlandsoppholdV2> {
+        if (oppholdListe.isEmpty()) return emptyList()
+        val sortertePerioder = oppholdListe.sortedBy { it.fom }
+
+        val sammenslaatte = mutableListOf<UtenlandsoppholdV2>()
+        var gjeldendePeriode = sortertePerioder.first()
+
+        for (periode in sortertePerioder.drop(1)) {
+            if (periode.fom <= (gjeldendePeriode.tom ?: LocalDate.now()).plusDays(1)) {
+                // Slå sammen perioder hvis de overlapper eller henger sammen
+                gjeldendePeriode = UtenlandsoppholdV2(
+                    fom = gjeldendePeriode.fom,
+                    tom = maxOf(gjeldendePeriode.tom ?: LocalDate.now(), periode.tom ?: LocalDate.now())
+                )
+            } else {
+                // Legg til gjeldende periode og start ny
+                sammenslaatte.add(gjeldendePeriode)
+                gjeldendePeriode = periode
+            }
+        }
+
+        // Legg til siste periode
+        sammenslaatte.add(gjeldendePeriode)
+        return sammenslaatte
+    }
+
+    private const val DAGER_PER_AAR = 365
+
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringSpecMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringSpecMapperV2.kt
@@ -82,16 +82,17 @@ object TjenestepensjonSimuleringSpecMapperV2 {
     }
 
     private fun antallAar(oppholdListe: List<UtenlandsoppholdV2>): Int {
-        val sammenslattePerioder = slaaSammenOverlappendePerioder(oppholdListe)
-        val antallDager = antallDager(sammenslattePerioder)
+        val dagensDato = LocalDate.now()
+        val sammenslattePerioder = slaaSammenOverlappendePerioder(oppholdListe, dagensDato)
+        val antallDager = antallDager(sammenslattePerioder, dagensDato)
         return (antallDager / DAGER_PER_AAR).toInt()
     }
 
-    private fun antallDager(oppholdListe: List<UtenlandsoppholdV2>): Long {
-        return oppholdListe.sumOf { (it.tom ?: LocalDate.now()).toEpochDay() + 1 - it.fom.toEpochDay() }
+    private fun antallDager(oppholdListe: List<UtenlandsoppholdV2>, dagensDato: LocalDate): Long {
+        return oppholdListe.sumOf { (it.tom ?: dagensDato).toEpochDay() + 1 - it.fom.toEpochDay() }
     }
 
-    private fun slaaSammenOverlappendePerioder(oppholdListe: List<UtenlandsoppholdV2>): List<UtenlandsoppholdV2> {
+    private fun slaaSammenOverlappendePerioder(oppholdListe: List<UtenlandsoppholdV2>, dagensDato: LocalDate): List<UtenlandsoppholdV2> {
         if (oppholdListe.isEmpty()) return emptyList()
         val sortertePerioder = oppholdListe.sortedBy { it.fom }
 
@@ -99,11 +100,11 @@ object TjenestepensjonSimuleringSpecMapperV2 {
         var gjeldendePeriode = sortertePerioder.first()
 
         for (periode in sortertePerioder.drop(1)) {
-            if (periode.fom <= (gjeldendePeriode.tom ?: LocalDate.now()).plusDays(1)) {
+            if (periode.fom <= (gjeldendePeriode.tom ?: dagensDato).plusDays(1)) {
                 // Slå sammen perioder hvis de overlapper eller henger sammen
                 gjeldendePeriode = UtenlandsoppholdV2(
                     fom = gjeldendePeriode.fom,
-                    tom = maxOf(gjeldendePeriode.tom ?: LocalDate.now(), periode.tom ?: LocalDate.now())
+                    tom = maxOf(gjeldendePeriode.tom ?: dagensDato, periode.tom ?: dagensDato)
                 )
             } else {
                 // Legg til gjeldende periode og start ny

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/TjenestepensjonSimuleringClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/TjenestepensjonSimuleringClient.kt
@@ -3,7 +3,16 @@ package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client
 import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.OffentligTjenestepensjonSimuleringsresultat
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.SimuleringOffentligTjenestepensjonSpec
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.SimuleringOffentligTjenestepensjonSpecV2
 
 interface TjenestepensjonSimuleringClient {
-    fun hentTjenestepensjonSimulering(request: SimuleringOffentligTjenestepensjonSpec, pid: Pid): OffentligTjenestepensjonSimuleringsresultat
+    fun hentTjenestepensjonSimulering(
+        request: SimuleringOffentligTjenestepensjonSpec,
+        pid: Pid
+    ): OffentligTjenestepensjonSimuleringsresultat
+
+    fun hentTjenestepensjonSimulering(
+        request: SimuleringOffentligTjenestepensjonSpecV2,
+        pid: Pid
+    ): OffentligTjenestepensjonSimuleringsresultat
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/SimuleringOffentligTjenestepensjonSpecV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/SimuleringOffentligTjenestepensjonSpecV2.kt
@@ -1,0 +1,16 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering
+
+import java.time.LocalDate
+
+data class SimuleringOffentligTjenestepensjonSpecV2(
+    val foedselsdato: LocalDate,
+    val uttaksdato: LocalDate,
+    val sisteInntekt: Int,
+    val fremtidigeInntekter: List<FremtidigInntektV2>,
+    val aarIUtlandetEtter16: Int,
+    val brukerBaOmAfp: Boolean,
+    val epsPensjon: Boolean,
+    val eps2G: Boolean,
+)
+
+data class FremtidigInntektV2(val fom: LocalDate, val beloep: Int)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/dto/SimuleringOFTPSpecDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/dto/SimuleringOFTPSpecDto.kt
@@ -11,4 +11,7 @@ data class SimuleringOFTPSpecDto(
     val brukerBaOmAfp: Boolean,
     val epsPensjon: Boolean,
     val eps2G: Boolean,
+    val fremtidigeInntekter: List<FremtidigInntektSimuleringOFTPSpecDto> = emptyList()
 )
+
+data class FremtidigInntektSimuleringOFTPSpecDto(val fraOgMed: LocalDate, val aarligInntekt: Int)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/map/TpSimuleringClientMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/map/TpSimuleringClientMapper.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.
 
 import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.*
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.dto.FremtidigInntektSimuleringOFTPSpecDto
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.dto.SimulerTjenestepensjonResponseDto
 import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.dto.SimuleringOFTPSpecDto
 
@@ -34,6 +35,23 @@ object TpSimuleringClientMapper {
         foedselsdato = spec.foedselsdato,
         uttaksdato = spec.uttaksdato,
         sisteInntekt = spec.sisteInntekt,
+        aarIUtlandetEtter16 = spec.aarIUtlandetEtter16,
+        brukerBaOmAfp = spec.brukerBaOmAfp,
+        epsPensjon = spec.epsPensjon,
+        eps2G = spec.eps2G,
+    )
+
+    fun toDto(spec: SimuleringOffentligTjenestepensjonSpecV2, pid: Pid) = SimuleringOFTPSpecDto(
+        pid = pid.value,
+        foedselsdato = spec.foedselsdato,
+        uttaksdato = spec.uttaksdato,
+        sisteInntekt = spec.sisteInntekt,
+        fremtidigeInntekter = spec.fremtidigeInntekter.map {
+            FremtidigInntektSimuleringOFTPSpecDto(
+                fraOgMed = it.fom,
+                aarligInntekt = it.beloep,
+            )
+        },
         aarIUtlandetEtter16 = spec.aarIUtlandetEtter16,
         brukerBaOmAfp = spec.brukerBaOmAfp,
         epsPensjon = spec.epsPensjon,

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/FremtidigInntektV2ServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/FremtidigInntektV2ServiceTest.kt
@@ -14,7 +14,7 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @ExtendWith(SpringExtension::class)
-class InntektServiceTest {
+class FremtidigInntektV2ServiceTest {
 
     private lateinit var service: InntektService
 

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/FremtidigInntektV2UtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/FremtidigInntektV2UtilTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import java.math.BigDecimal
 
-class InntektUtilTest {
+class FremtidigInntektV2UtilTest {
 
     @Test
     fun `pensjonsgivendeInntekt gir 0 hvis ingen inntekter`() {

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/FremtidigInntektV2ControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/FremtidigInntektV2ControllerTest.kt
@@ -25,7 +25,7 @@ import java.math.BigDecimal
 
 @WebMvcTest(InntektController::class)
 @Import(MockSecurityConfiguration::class)
-class InntektControllerTest {
+class FremtidigInntektV2ControllerTest {
 
     @Autowired
     private lateinit var mvc: MockMvc

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/map/FremtidigInntektV2MapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/map/FremtidigInntektV2MapperTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
-class InntektMapperTest {
+class FremtidigInntektV2MapperTest {
 
     @Test
     fun `toDto maps aar and beloep`() {

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringControllerTest.kt
@@ -47,8 +47,8 @@ class TjenestepensjonSimuleringControllerTest {
     private lateinit var auditor: Auditor
 
     @Test
-    fun `simuler offentlig tjenestepensjon`() {
-        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_OK_V1)
+    fun `simuler offentlig tjenestepensjon V1`() {
+        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_OK_V2)
 
         mvc.perform(
             post(URL_V1)
@@ -61,8 +61,22 @@ class TjenestepensjonSimuleringControllerTest {
     }
 
     @Test
+    fun `simuler offentlig tjenestepensjon V2`() {
+        `when`(service.hentTjenestepensjonSimuleringV2(anyNonNull())).thenReturn(RESULTAT_OK_V2)
+
+        mvc.perform(
+            post(URL_V2)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY_V2)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(RESPONSE_BODY_OK_V1))
+    }
+
+    @Test
     fun `simuler offentlig tjenestepensjon hvor det feiler hos tp-ordning`() {
-        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_TEKNISK_FEIL_V1)
+        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_TEKNISK_FEIL_V2)
 
         mvc.perform(
             post(URL_V1)
@@ -71,12 +85,12 @@ class TjenestepensjonSimuleringControllerTest {
                 .content(REQUEST_BODY_V1)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_TEKNISK_FEIL_V1))
+            .andExpect(content().json(RESPONSE_BODY_TEKNISK_FEIL_V2))
     }
 
     @Test
     fun `simuler offentlig tjenestepensjon naar bruker ikke er medlem`() {
-        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_BRUKER_ER_IKKE_MEDLEM_V1)
+        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_BRUKER_ER_IKKE_MEDLEM_V2)
 
         mvc.perform(
             post(URL_V1)
@@ -85,12 +99,12 @@ class TjenestepensjonSimuleringControllerTest {
                 .content(REQUEST_BODY_V1)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_BRUKER_ER_IKKE_MEDLEM_V1))
+            .andExpect(content().json(RESPONSE_BODY_BRUKER_ER_IKKE_MEDLEM_V2))
     }
 
     @Test
     fun `simuler offentlig tjenestepensjon naar bruker er medlem hos TP-ordning som ikke stoettes`() {
-        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_TP_ORDNING_STOETTES_IKKE_V1)
+        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_TP_ORDNING_STOETTES_IKKE_V2)
 
         mvc.perform(
             post(URL_V1)
@@ -99,12 +113,12 @@ class TjenestepensjonSimuleringControllerTest {
                 .content(REQUEST_BODY_V1)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_TP_ORDNING_STOETTES_IKKE_V1))
+            .andExpect(content().json(RESPONSE_BODY_TP_ORDNING_STOETTES_IKKE_V2))
     }
 
     @Test
     fun `simuler offentlig tjenestepensjon naar TP-ordning returnerer tom respons`() {
-        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_TOM_RESPONS_FRA_TP_ORDNING_V1)
+        `when`(service.hentTjenestepensjonSimulering(anyNonNull())).thenReturn(RESULTAT_TOM_RESPONS_FRA_TP_ORDNING_V2)
 
         mvc.perform(
             post(URL_V1)
@@ -113,7 +127,7 @@ class TjenestepensjonSimuleringControllerTest {
                 .content(REQUEST_BODY_V1)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_TOM_RESPONS_FRA_TP_ORDNING_V1))
+            .andExpect(content().json(RESPONSE_BODY_TOM_RESPONS_FRA_TP_ORDNING_V2))
     }
 
     @Test
@@ -131,6 +145,7 @@ class TjenestepensjonSimuleringControllerTest {
 
     private companion object {
         private const val URL_V1 = "/api/v1/simuler-oftp"
+        private const val URL_V2 = "/api/v2/simuler-oftp"
         @Language("json")
         private const val RESPONSE_BODY_OK_V1 = """{
     "simuleringsresultatStatus": "OK",
@@ -188,7 +203,32 @@ class TjenestepensjonSimuleringControllerTest {
     "brukerBaOmAfpOffentlig": false
 }"""
 
-        private val RESULTAT_OK_V1 = OffentligTjenestepensjonSimuleringsresultat(
+        private const val REQUEST_BODY_V2 = """{
+    "foedselsdato": "1964-01-02",
+    "aarligInntektFoerUttakBeloep": 900000,
+    "gradertUttak": {
+        "uttaksalder": { "aar": 63, "maaneder": 0 },
+        "aarligInntektVsaPensjonBeloep": 75000
+    },
+    "heltUttak": {
+        "uttaksalder": { "aar": 67, "maaneder": 1 },
+        "aarligInntektVsaPensjon": {
+           "beloep": 50000,
+           "sluttAlder": { "aar": 75, "maaneder": 0 } 
+        }
+    },
+    "utenlandsperiodeListe": [
+        {
+            "fom": "2020-01-01",
+            "tom": "2021-01-01"
+        }
+    ],
+    "epsHarPensjon": false,
+    "epsHarInntektOver2G": false,
+    "brukerBaOmAfp": false
+}"""
+
+        private val RESULTAT_OK_V2 = OffentligTjenestepensjonSimuleringsresultat(
             simuleringsResultatStatus = SimuleringsResultatStatus(resultatType = ResultatType.OK, feilmelding = null),
             simuleringsResultat = SimuleringsResultat(
                 tpOrdning = "Statens Pensjonskasse",
@@ -204,40 +244,40 @@ class TjenestepensjonSimuleringControllerTest {
             tpOrdninger = listOf("Statens pensjonskasse")
         )
 
-        private const val RESPONSE_BODY_TEKNISK_FEIL_V1 = """{
+        private const val RESPONSE_BODY_TEKNISK_FEIL_V2 = """{
         "simuleringsresultatStatus": "TEKNISK_FEIL",
         "muligeTpLeverandoerListe": [
             "Bodø kommunale pensjonskasse",
             "Statens pensjonskasse"
         ]
     }"""
-        private val RESULTAT_TEKNISK_FEIL_V1 = OffentligTjenestepensjonSimuleringsresultat(
+        private val RESULTAT_TEKNISK_FEIL_V2 = OffentligTjenestepensjonSimuleringsresultat(
             simuleringsResultatStatus = SimuleringsResultatStatus(resultatType = ResultatType.TEKNISK_FEIL, feilmelding = "Noe gikk galt"),
             tpOrdninger = listOf("Bodø kommunale pensjonskasse","Statens pensjonskasse")
         )
 
-        private const val RESPONSE_BODY_BRUKER_ER_IKKE_MEDLEM_V1 = """{
+        private const val RESPONSE_BODY_BRUKER_ER_IKKE_MEDLEM_V2 = """{
         "simuleringsresultatStatus": "BRUKER_ER_IKKE_MEDLEM_AV_TP_ORDNING",
         "muligeTpLeverandoerListe": []
     }"""
-        private val RESULTAT_BRUKER_ER_IKKE_MEDLEM_V1 = OffentligTjenestepensjonSimuleringsresultat(
+        private val RESULTAT_BRUKER_ER_IKKE_MEDLEM_V2 = OffentligTjenestepensjonSimuleringsresultat(
             simuleringsResultatStatus = SimuleringsResultatStatus(resultatType = ResultatType.IKKE_MEDLEM, feilmelding = "Ikke medlem")
         )
 
-        private const val RESPONSE_BODY_TP_ORDNING_STOETTES_IKKE_V1 = """{
+        private const val RESPONSE_BODY_TP_ORDNING_STOETTES_IKKE_V2 = """{
         "simuleringsresultatStatus": "TP_ORDNING_STOETTES_IKKE",
             "muligeTpLeverandoerListe": ["Pensjonstrygden uten navn"]
     }"""
-        private val RESULTAT_TP_ORDNING_STOETTES_IKKE_V1 = OffentligTjenestepensjonSimuleringsresultat(
+        private val RESULTAT_TP_ORDNING_STOETTES_IKKE_V2 = OffentligTjenestepensjonSimuleringsresultat(
             simuleringsResultatStatus = SimuleringsResultatStatus(resultatType = ResultatType.TP_ORDNING_STOETTES_IKKE, feilmelding = "TP-ordning støttes ikke"),
             tpOrdninger = listOf("Pensjonstrygden uten navn")
         )
 
-        private const val RESPONSE_BODY_TOM_RESPONS_FRA_TP_ORDNING_V1 = """{
+        private const val RESPONSE_BODY_TOM_RESPONS_FRA_TP_ORDNING_V2 = """{
         "simuleringsresultatStatus": "TOM_SIMULERING_FRA_TP_ORDNING",
             "muligeTpLeverandoerListe": ["Pensjonstrygden med navn"]
     }"""
-        private val RESULTAT_TOM_RESPONS_FRA_TP_ORDNING_V1 = OffentligTjenestepensjonSimuleringsresultat(
+        private val RESULTAT_TOM_RESPONS_FRA_TP_ORDNING_V2 = OffentligTjenestepensjonSimuleringsresultat(
             simuleringsResultatStatus = SimuleringsResultatStatus(resultatType = ResultatType.TOM_RESPONS, feilmelding = "Ingen utbetalingsperioder fra TP-ordning"),
             tpOrdninger = listOf("Pensjonstrygden med navn")
         )

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringServiceTest.kt
@@ -36,11 +36,21 @@ class TjenestepensjonSimuleringServiceTest {
     }
 
     @Test
-    fun `hent pid, map request og hent simulering fra client`() {
-        val request = SimuleringOffentligTjenestepensjonSpec(
+    fun `hent pid, map request V2 og hent simulering fra client`() {
+        val request = SimuleringOffentligTjenestepensjonSpecV2(
             foedselsdato = LocalDate.parse("1990-01-01"),
             uttaksdato = LocalDate.of(2053, 3, 1),
             sisteInntekt = 500000,
+            fremtidigeInntekter = listOf(
+                FremtidigInntektV2(
+                    fom = LocalDate.of(2053, 3, 1),
+                    beloep = 500000
+                ),
+                FremtidigInntektV2(
+                    fom = LocalDate.of(2060, 3, 1),
+                    beloep = 0
+                )
+            ),
             aarIUtlandetEtter16 = 6,
             brukerBaOmAfp = true,
             epsPensjon = true,
@@ -62,7 +72,7 @@ class TjenestepensjonSimuleringServiceTest {
             )
         )
 
-        val result = service.hentTjenestepensjonSimulering(request)
+        val result = service.hentTjenestepensjonSimuleringV2(request)
 
         assertNotNull(result)
         assertEquals(ResultatType.OK, result.simuleringsResultatStatus.resultatType)

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2Test.kt
@@ -1,0 +1,46 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map
+
+import no.nav.pensjon.kalkulator.general.Alder
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.OffentligTjenestepensjonSimuleringsresultatDtoV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.SimuleringsresultatStatusV2
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TjenestepensjonSimuleringResultMapperV2Test{
+
+    @Test
+    fun `map all fields to dto and convert monthly to annual payout`() {
+        val start = Alder(62, 0)
+        val slutt = Alder(63, 0)
+        val source = OffentligTjenestepensjonSimuleringsresultat(
+            simuleringsResultatStatus = SimuleringsResultatStatus(
+                resultatType = ResultatType.OK,
+                feilmelding = "feilmelding"
+            ),
+            simuleringsResultat = SimuleringsResultat(
+                tpOrdning = "tpOrdningX",
+                perioder = listOf(
+                    Utbetaling(
+                        startAlder = start,
+                        sluttAlder = slutt,
+                        maanedligBeloep = 100
+                    )
+                ),
+                betingetTjenestepensjonInkludert = true
+            ),
+            tpOrdninger = listOf("tpOrdningY")
+        )
+
+        val result: OffentligTjenestepensjonSimuleringsresultatDtoV2 = TjenestepensjonSimuleringResultMapperV2.toDtoV2(source)
+
+        assertEquals(SimuleringsresultatStatusV2.OK, result.simuleringsresultatStatus)
+        assertEquals("tpOrdningY", result.muligeTpLeverandoerListe[0])
+        assertEquals("tpOrdningX", result.simulertTjenestepensjon?.tpLeverandoer)
+        assertEquals(start, result.simulertTjenestepensjon?.simuleringsresultat?.utbetalingsperioder?.get(0)?.startAlder)
+        assertEquals(slutt, result.simulertTjenestepensjon?.simuleringsresultat?.utbetalingsperioder?.get(0)?.sluttAlder)
+        assertEquals(1200, result.simulertTjenestepensjon?.simuleringsresultat?.utbetalingsperioder?.get(0)?.aarligUtbetaling)
+        assertTrue(result.simulertTjenestepensjon?.simuleringsresultat?.betingetTjenestepensjonErInkludert!!)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringSpecMapperV2Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringSpecMapperV2Test.kt
@@ -1,0 +1,249 @@
+package no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.map
+
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.api.dto.*
+import no.nav.pensjon.kalkulator.tjenestepensjonsimulering.client.tpsimulering.SimuleringOffentligTjenestepensjonSpecV2
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.Period
+
+class TjenestepensjonSimuleringSpecMapperV2Test {
+
+    @Test
+    fun `map from dto med utenlandsperioder, gradert og helt uttak med inntekter`() {
+        val spec = IngressSimuleringOffentligTjenestepensjonSpecV2(
+            foedselsdato = LocalDate.parse("1963-02-24"),
+            aarligInntektFoerUttakBeloep = 1,
+            gradertUttak = SimuleringOffentligTjenestepensjonGradertUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(63, 0),
+                aarligInntektVsaPensjonBeloep = 2
+            ),
+            heltUttak = SimuleringOffentligTjenestepensjonHeltUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(65, 11),
+                aarligInntektVsaPensjon = SimuleringOffentligTjenestepensjonInntektV2(
+                    3,
+                    SimuleringOffentligTjenestepensjonAlderV2(70, 0)
+                )
+            ),
+            utenlandsperiodeListe = listOf(
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2020-01-01"),
+                    tom = LocalDate.parse("2021-12-31")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2022-01-01"),
+                    tom = LocalDate.parse("2022-12-31")
+                )
+            ),
+            epsHarPensjon = true,
+            epsHarInntektOver2G = true,
+            brukerBaOmAfp = true
+        )
+
+        val result: SimuleringOffentligTjenestepensjonSpecV2 = TjenestepensjonSimuleringSpecMapperV2.fromDtoV2(spec)
+
+        assertEquals(LocalDate.parse("1963-02-24"), result.foedselsdato)
+        assertEquals(LocalDate.parse("2026-03-01"), result.uttaksdato)
+        assertEquals(1, result.sisteInntekt)
+        assertEquals(3, result.fremtidigeInntekter.size)
+        assertEquals(2, result.fremtidigeInntekter[0].beloep)
+        assertEquals(LocalDate.parse("2026-03-01"), result.fremtidigeInntekter[0].fom)
+        assertEquals(3, result.fremtidigeInntekter[1].beloep)
+        assertEquals(LocalDate.parse("2029-02-01"), result.fremtidigeInntekter[1].fom)
+        assertEquals(0, result.fremtidigeInntekter[2].beloep)
+        assertEquals(LocalDate.parse("2033-04-01"), result.fremtidigeInntekter[2].fom)
+        assertEquals(3, result.aarIUtlandetEtter16)
+        assertEquals(true, result.brukerBaOmAfp)
+        assertEquals(true, result.epsPensjon)
+        assertEquals(true, result.eps2G)
+    }
+
+    @Test
+    fun `map from dto med gradert uttak uten inntekt med helt uttak med inntekt`() {
+        val spec = IngressSimuleringOffentligTjenestepensjonSpecV2(
+            foedselsdato = LocalDate.parse("1963-02-24"),
+            aarligInntektFoerUttakBeloep = 1,
+            gradertUttak = SimuleringOffentligTjenestepensjonGradertUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(63, 0),
+                aarligInntektVsaPensjonBeloep = null
+            ),
+            heltUttak = SimuleringOffentligTjenestepensjonHeltUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(65, 11),
+                aarligInntektVsaPensjon = SimuleringOffentligTjenestepensjonInntektV2(
+                    3,
+                    SimuleringOffentligTjenestepensjonAlderV2(70, 0)
+                )
+            ),
+            utenlandsperiodeListe = emptyList(),
+            epsHarPensjon = true,
+            epsHarInntektOver2G = true,
+            brukerBaOmAfp = true
+        )
+
+        val result: SimuleringOffentligTjenestepensjonSpecV2 = TjenestepensjonSimuleringSpecMapperV2.fromDtoV2(spec)
+
+        assertEquals(2, result.fremtidigeInntekter.size)
+        assertEquals(3, result.fremtidigeInntekter[0].beloep)
+        assertEquals(LocalDate.parse("2029-02-01"), result.fremtidigeInntekter[0].fom)
+        assertEquals(0, result.fremtidigeInntekter[1].beloep)
+        assertEquals(LocalDate.parse("2033-04-01"), result.fremtidigeInntekter[1].fom)
+    }
+
+    @Test
+    fun `map from dto med gradert uttak med inntekt og helt uttak uten inntekt`() {
+        val spec = IngressSimuleringOffentligTjenestepensjonSpecV2(
+            foedselsdato = LocalDate.parse("1963-02-24"),
+            aarligInntektFoerUttakBeloep = 1,
+            gradertUttak = SimuleringOffentligTjenestepensjonGradertUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(63, 0),
+                aarligInntektVsaPensjonBeloep = 2
+            ),
+            heltUttak = SimuleringOffentligTjenestepensjonHeltUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(65, 11),
+                aarligInntektVsaPensjon = null
+            ),
+            utenlandsperiodeListe = emptyList(),
+            epsHarPensjon = true,
+            epsHarInntektOver2G = true,
+            brukerBaOmAfp = true
+        )
+
+        val result: SimuleringOffentligTjenestepensjonSpecV2 = TjenestepensjonSimuleringSpecMapperV2.fromDtoV2(spec)
+
+        assertEquals(2, result.fremtidigeInntekter.size)
+        assertEquals(2, result.fremtidigeInntekter[0].beloep)
+        assertEquals(LocalDate.parse("2026-03-01"), result.fremtidigeInntekter[0].fom)
+        assertEquals(0, result.fremtidigeInntekter[1].beloep)
+        assertEquals(LocalDate.parse("2029-02-01"), result.fremtidigeInntekter[1].fom)
+    }
+
+    @Test
+    fun `map from dto med gradert uttak uten inntekt og helt uttak uten inntekt`() {
+        val spec = IngressSimuleringOffentligTjenestepensjonSpecV2(
+            foedselsdato = LocalDate.parse("1963-02-24"),
+            aarligInntektFoerUttakBeloep = 1,
+            gradertUttak = SimuleringOffentligTjenestepensjonGradertUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(63, 0),
+                aarligInntektVsaPensjonBeloep = null
+            ),
+            heltUttak = SimuleringOffentligTjenestepensjonHeltUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(65, 11),
+                aarligInntektVsaPensjon = null
+            ),
+            utenlandsperiodeListe = emptyList(),
+            epsHarPensjon = true,
+            epsHarInntektOver2G = true,
+            brukerBaOmAfp = true
+        )
+
+        val result: SimuleringOffentligTjenestepensjonSpecV2 = TjenestepensjonSimuleringSpecMapperV2.fromDtoV2(spec)
+
+        assertEquals(1, result.fremtidigeInntekter.size)
+        assertEquals(0, result.fremtidigeInntekter[0].beloep)
+        assertEquals(LocalDate.parse("2026-03-01"), result.fremtidigeInntekter[0].fom)
+    }
+
+    @Test
+    fun `fromDto haandterer overlappende perioder`() {
+        val spec = IngressSimuleringOffentligTjenestepensjonSpecV2(
+            foedselsdato = LocalDate.parse("1963-02-24"),
+            aarligInntektFoerUttakBeloep = 1,
+            gradertUttak = null,
+            heltUttak = SimuleringOffentligTjenestepensjonHeltUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(63, 0),
+                aarligInntektVsaPensjon = SimuleringOffentligTjenestepensjonInntektV2(
+                    3,
+                    SimuleringOffentligTjenestepensjonAlderV2(70, 0)
+                )
+            ),
+            utenlandsperiodeListe = listOf(
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2020-01-01"),
+                    tom = LocalDate.parse("2022-12-31")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2020-01-01"),
+                    tom = LocalDate.parse("2021-12-31")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2020-03-31"),
+                    tom = LocalDate.parse("2021-06-30")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2022-09-30"),
+                    tom = LocalDate.parse("2022-12-30")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2021-01-01"),
+                    tom = LocalDate.parse("2022-12-31")
+                ),
+            ),
+            epsHarPensjon = true,
+            epsHarInntektOver2G = true,
+            brukerBaOmAfp = true
+        )
+
+        val result = TjenestepensjonSimuleringSpecMapperV2.fromDtoV2(spec)
+
+        assertEquals(LocalDate.parse("1963-02-24"), result.foedselsdato)
+        assertEquals(LocalDate.parse("2026-03-01"), result.uttaksdato)
+        assertEquals(1, result.sisteInntekt)
+        assertEquals(3, result.aarIUtlandetEtter16)
+        assertEquals(true, result.brukerBaOmAfp)
+        assertEquals(true, result.epsPensjon)
+        assertEquals(true, result.eps2G)
+    }
+
+    @Test
+    fun `fromDto haandterer overlappende perioder uten til og med dato`() {
+        val fom = LocalDate.parse("2021-11-29")
+        val antallAar = Period.between(fom, LocalDate.now().plusDays(1)).years //fom - inclusive, tom - inclusive too
+        val spec = IngressSimuleringOffentligTjenestepensjonSpecV2(
+            foedselsdato = LocalDate.parse("1963-02-24"),
+            gradertUttak = null,
+            heltUttak = SimuleringOffentligTjenestepensjonHeltUttakV2(
+                uttaksalder = SimuleringOffentligTjenestepensjonAlderV2(63, 0),
+                aarligInntektVsaPensjon = SimuleringOffentligTjenestepensjonInntektV2(
+                    3,
+                    SimuleringOffentligTjenestepensjonAlderV2(70, 0)
+                )
+            ),
+            aarligInntektFoerUttakBeloep = 1,
+            utenlandsperiodeListe = listOf(
+                UtenlandsoppholdV2(
+                    fom = fom,
+                    tom = LocalDate.parse("2022-02-01")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2022-01-01"),
+                    tom = LocalDate.parse("2022-12-31")
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2022-12-01"),
+                    tom = null
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2023-12-01"),
+                    tom = null
+                ),
+                UtenlandsoppholdV2(
+                    fom = LocalDate.parse("2024-12-01"),
+                    tom = null
+                ),
+            ),
+            epsHarPensjon = true,
+            epsHarInntektOver2G = true,
+            brukerBaOmAfp = true
+        )
+
+        val result = TjenestepensjonSimuleringSpecMapperV2.fromDtoV2(spec)
+
+        assertEquals(LocalDate.parse("1963-02-24"), result.foedselsdato)
+        assertEquals(LocalDate.parse("2026-03-01"), result.uttaksdato)
+        assertEquals(1, result.sisteInntekt)
+        assertEquals(antallAar, result.aarIUtlandetEtter16)
+        assertEquals(true, result.brukerBaOmAfp)
+        assertEquals(true, result.epsPensjon)
+        assertEquals(true, result.eps2G)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/TpSimuleringClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/TpSimuleringClientTest.kt
@@ -42,10 +42,11 @@ class TpSimuleringClientTest : WebClientTest() {
     @Test
     fun `hent tjenestepensjonSimulering hvor responsen har ingen utbetalingsperioder`() {
         arrange(ingenUtbetalingsperioderResponse())
-        val req = SimuleringOffentligTjenestepensjonSpec(
+        val req = SimuleringOffentligTjenestepensjonSpecV2(
             foedselsdato = LocalDate.of(1964, 2, 3),
             uttaksdato = LocalDate.of(2027, 2, 3),
             sisteInntekt = 0,
+            fremtidigeInntekter = emptyList(),
             aarIUtlandetEtter16 = 1,
             brukerBaOmAfp = true,
             epsPensjon = true,
@@ -62,10 +63,15 @@ class TpSimuleringClientTest : WebClientTest() {
     @Test
     fun `hent tjenestepensjon simulering OK`() {
         arrange(okResponse())
-        val req = SimuleringOffentligTjenestepensjonSpec(
+        val req = SimuleringOffentligTjenestepensjonSpecV2(
             foedselsdato = LocalDate.of(1964, 2, 3),
             uttaksdato = LocalDate.of(2027, 2, 3),
             sisteInntekt = 500000,
+            fremtidigeInntekter = listOf(
+                FremtidigInntektV2(LocalDate.of(2028, 1, 1), 600000),
+                FremtidigInntektV2(LocalDate.of(2029, 1, 1), 700000),
+                FremtidigInntektV2(LocalDate.of(2030, 1, 1), 0),
+            ),
             aarIUtlandetEtter16 = 1,
             brukerBaOmAfp = true,
             epsPensjon = true,
@@ -99,10 +105,11 @@ class TpSimuleringClientTest : WebClientTest() {
     @Test
     fun `hent tjenestepensjon simulering for bruker som ikke er medlem`() {
         arrange(ikkeMedlemResponse())
-        val req = SimuleringOffentligTjenestepensjonSpec(
+        val req = SimuleringOffentligTjenestepensjonSpecV2(
             foedselsdato = LocalDate.of(1964, 2, 3),
-            uttaksdato = LocalDate.of(2027, 2, 3),
+            uttaksdato = LocalDate.of(2027, 2, 1),
             sisteInntekt = 500000,
+            fremtidigeInntekter = listOf(FremtidigInntektV2(LocalDate.of(2027, 2, 1), 0),),
             aarIUtlandetEtter16 = 1,
             brukerBaOmAfp = true,
             epsPensjon = true,
@@ -119,10 +126,11 @@ class TpSimuleringClientTest : WebClientTest() {
     @Test
     fun `hent tjenestepensjon simulering for tp-ordning som ikke stoettes`() {
         arrange(tpOrdningStoettesIkkeResponse())
-        val req = SimuleringOffentligTjenestepensjonSpec(
+        val req = SimuleringOffentligTjenestepensjonSpecV2(
             foedselsdato = LocalDate.of(1964, 2, 3),
             uttaksdato = LocalDate.of(2027, 2, 3),
             sisteInntekt = 500000,
+            fremtidigeInntekter = listOf(FremtidigInntektV2(LocalDate.of(2027, 2, 1), 0),),
             aarIUtlandetEtter16 = 1,
             brukerBaOmAfp = true,
             epsPensjon = true,
@@ -140,10 +148,11 @@ class TpSimuleringClientTest : WebClientTest() {
     @Test
     fun `hent tjenestepensjon simulering kom med teksnisk feil fra tp-ordning`() {
         arrange(tekniskFeilResponse())
-        val req = SimuleringOffentligTjenestepensjonSpec(
+        val req = SimuleringOffentligTjenestepensjonSpecV2(
             foedselsdato = LocalDate.of(1964, 2, 3),
             uttaksdato = LocalDate.of(2027, 2, 3),
             sisteInntekt = 500000,
+            fremtidigeInntekter = listOf(FremtidigInntektV2(LocalDate.of(2027, 2, 1), 0),),
             aarIUtlandetEtter16 = 1,
             brukerBaOmAfp = true,
             epsPensjon = true,


### PR DESCRIPTION
Mapping av Inntekter til fremtidige inntekter

0-inntekt kan starte fra:
1. uttaksdato for gradert uttak, hvis ingen inntekt ved siden av gradert og helt uttak
2. uttaksdato for helt uttak, hvis ingen inntekt ved siden av helt uttak etter inntekt ved siden av gradert uttak
3. en måned etter dato ved sluttalderen for inntekten ved siden av helt uttak