### PR TITLE
Ta i bruk serviceData fra tjenestepensjon-simulering

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/dto/OffentligTjenestepensjonSimuleringsresultatDtoV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/dto/OffentligTjenestepensjonSimuleringsresultatDtoV2.kt
@@ -9,6 +9,7 @@ data class OffentligTjenestepensjonSimuleringsresultatDtoV2 (
     val simuleringsresultatStatus: SimuleringsresultatStatusV2 = SimuleringsresultatStatusV2.OK,
     val muligeTpLeverandoerListe: List<String> = emptyList(),
     val simulertTjenestepensjon: SimulertTjenestepensjonV2? = null,
+    var serviceData: List<String> = emptyList(),
 )
 
 enum class SimuleringsresultatStatusV2(val resultatType: ResultatType?) {

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/api/map/TjenestepensjonSimuleringResultMapperV2.kt
@@ -19,5 +19,6 @@ object TjenestepensjonSimuleringResultMapperV2 {
                 )
             )
         },
+        serviceData = simuleringsresultat.serviceData
     )
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/OffentligTjenestepensjonSimuleringsresultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/OffentligTjenestepensjonSimuleringsresultat.kt
@@ -7,6 +7,7 @@ data class OffentligTjenestepensjonSimuleringsresultat(
     val simuleringsResultatStatus: SimuleringsResultatStatus,
     val simuleringsResultat: SimuleringsResultat? = null,
     val tpOrdninger: List<String> = emptyList(),
+    var serviceData: List<String> = emptyList(),
 )
 
 data class SimuleringsResultatStatus(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/dto/SimulerTjenestepensjonResponseDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/dto/SimulerTjenestepensjonResponseDto.kt
@@ -6,6 +6,7 @@ data class SimulerTjenestepensjonResponseDto(
     val simuleringsResultatStatus: SimuleringsResultatStatusDto,
     val simuleringsResultat: SimuleringsResultatDto? = null,
     val relevanteTpOrdninger: List<String> = emptyList(),
+    var serviceData: List<String>? = emptyList(),
 )
 
 data class SimuleringsResultatStatusDto(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/map/TpSimuleringClientMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/client/tpsimulering/map/TpSimuleringClientMapper.kt
@@ -28,6 +28,7 @@ object TpSimuleringClientMapper {
             )
         },
         tpOrdninger = dto.relevanteTpOrdninger,
+        serviceData = dto.serviceData.orEmpty(),
     )
 
     fun toDto(spec: SimuleringOffentligTjenestepensjonSpec, pid: Pid) = SimuleringOFTPSpecDto(


### PR DESCRIPTION
Debug tjenstepensjon-simulering sammen med SPK
Eksempel på tilleggsopplysninger om request/response til SPK:
```
 "serviceData": [
        "Request: SPKSimulerTjenestepensjonRequest(personId=01810198296, uttaksListe=[Uttak(ytelseType=PAASLAG, fraOgMedDato=2065-01-01, uttaksgrad=null), Uttak(ytelseType=APOF2020, fraOgMedDato=2065-01-01, uttaksgrad=null), Uttak(ytelseType=OT6370, fraOgMedDato=2065-01-01, uttaksgrad=null), Uttak(ytelseType=SAERALDERSPAASLAG, fraOgMedDato=2065-01-01, uttaksgrad=null), Uttak(ytelseType=BTP, fraOgMedDato=2065-01-01, uttaksgrad=null)], fremtidigInntektListe=[FremtidigInntekt(aarligInntekt=380410, fraOgMedDato=2023-01-01), FremtidigInntekt(aarligInntekt=0, fraOgMedDato=2065-01-01)], aarIUtlandetEtter16=0, epsPensjon=false, eps2G=false)",
        "Response: SPKSimulerTjenestepensjonResponse(inkludertOrdningListe=[InkludertOrdning(tpnr=3010)], utbetalingListe=[Utbetaling(fraOgMedDato=2065-01-01, delytelseListe=[Delytelse(ytelseType=BTP, maanedligBelop=2757), Delytelse(ytelseType=PAASLAG, maanedligBelop=5481)])], aarsakIngenUtbetaling=[AarsakIngenUtbetaling(statusKode=VILKAAR_IKKE_OPPFYLT, statusBeskrivelse=Vilkaar ikke oppfylt, ytelseType=APOF2020), AarsakIngenUtbetaling(statusKode=VILKAAR_IKKE_OPPFYLT, statusBeskrivelse=Vilkaar ikke oppfylt, ytelseType=OT6370), AarsakIngenUtbetaling(statusKode=IKKE_STOETTET, statusBeskrivelse=Ikke stoettet, ytelseType=SAERALDERSPAASLAG)])"
    ]
```