### PR TITLE
PEK-846 Require high security if 'strengt fortrolig adresse'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/SecurityConfiguration.kt
@@ -5,6 +5,7 @@ import no.nav.pensjon.kalkulator.tech.security.egress.SecurityContextEnricher
 import no.nav.pensjon.kalkulator.tech.security.ingress.AudienceValidator
 import no.nav.pensjon.kalkulator.tech.security.ingress.AuthenticationEnricherFilter
 import no.nav.pensjon.kalkulator.tech.security.ingress.LoggingAuthenticationEntryPoint
+import no.nav.pensjon.kalkulator.tech.security.ingress.SecurityLevelFilter
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.ImpersonalAccessFilter
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.SecurityContextNavIdExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.jwt.RequestClaimExtractor
@@ -128,6 +129,7 @@ class SecurityConfiguration(private val requestClaimExtractor: RequestClaimExtra
         http: HttpSecurity,
         securityContextEnricher: SecurityContextEnricher,
         impersonalAccessFilter: ImpersonalAccessFilter,
+        securityLevelFilter: SecurityLevelFilter,
         authResolver: AuthenticationManagerResolver<HttpServletRequest>,
         authenticationEntryPoint: LoggingAuthenticationEntryPoint,
         @Value("\${pkb.request-matcher.internal}") internalRequestMatcher: String
@@ -137,6 +139,7 @@ class SecurityConfiguration(private val requestClaimExtractor: RequestClaimExtra
             BasicAuthenticationFilter::class.java
         )
             .addFilterAfter(impersonalAccessFilter, AuthenticationEnricherFilter::class.java)
+            .addFilterAfter(securityLevelFilter, ImpersonalAccessFilter::class.java)
 
         return http.csrf {
             it.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/EgressAccess.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/EgressAccess.kt
@@ -2,14 +2,18 @@ package no.nav.pensjon.kalkulator.tech.security.egress
 
 import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressService
 import no.nav.pensjon.kalkulator.tech.security.egress.token.RawJwt
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.jwt.Jwt
 
 object EgressAccess {
 
-    fun token(service: EgressService): RawJwt =
-        SecurityContextHolder.getContext().authentication.enriched().getEgressAccessToken(
+    fun token(service: EgressService): RawJwt {
+        val authentication = SecurityContextHolder.getContext()?.authentication
+
+        return authentication?.enriched()?.getEgressAccessToken(
             service,
-            ingressToken = (SecurityContextHolder.getContext().authentication?.credentials as? Jwt)?.tokenValue
-        )
+            ingressToken = (authentication.credentials as? Jwt)?.tokenValue
+        ) ?: throw AuthenticationCredentialsNotFoundException("failed to get egress access token")
+    }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/EnrichedAuthentication.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/EnrichedAuthentication.kt
@@ -2,11 +2,13 @@ package no.nav.pensjon.kalkulator.tech.security.egress
 
 import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonTarget
+import no.nav.pensjon.kalkulator.tech.representasjon.RepresentertRolle
 import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressService
 import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressTokenSuppliersByService
 import no.nav.pensjon.kalkulator.tech.security.egress.token.RawJwt
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
 
 /**
  * Authentication data is initially obtained by Spring Security.
@@ -24,6 +26,10 @@ class EnrichedAuthentication(
         egressTokenSuppliersByService.value[service]?.apply(ingressToken) ?: RawJwt("")
 
     fun needFulltNavn(): Boolean = target.rolle.needFulltNavn
+
+    fun veilederInnlogget(): Boolean = target.rolle == RepresentertRolle.UNDER_VEILEDNING
+
+    fun getClaim(key: String): String? = (credentials as? Jwt)?.claims[key] as? String
 
     fun targetPid(): Pid? = target.pid
 

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/EnrichedAuthentication.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/EnrichedAuthentication.kt
@@ -50,4 +50,4 @@ class EnrichedAuthentication(
     }
 }
 
-fun Authentication.enriched(): EnrichedAuthentication = this as EnrichedAuthentication
+fun Authentication.enriched(): EnrichedAuthentication? = this as? EnrichedAuthentication

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilter.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilter.kt
@@ -1,0 +1,60 @@
+package no.nav.pensjon.kalkulator.tech.security.ingress
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import no.nav.pensjon.kalkulator.person.Fortrolighet
+import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.tech.security.egress.EnrichedAuthentication
+import no.nav.pensjon.kalkulator.tech.security.egress.enriched
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.GenericFilterBean
+
+/**
+ * Sjekker om bruker har logget inn med tilstrekkelig sikkerhetsnivå.
+ */
+@Component
+class SecurityLevelFilter(
+    private val adresseService: FortroligAdresseService,
+    private val pidGetter: PidGetter
+) : GenericFilterBean() {
+
+    private val log = KotlinLogging.logger {}
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        try {
+            with(authentication()) {
+                if (veilederInnlogget().not())
+                    getClaim(SECURITY_LEVEL_CLAIM_KEY)?.let(::validate)
+            }
+        } catch (e: AccessDeniedException) {
+            log.warn { "Access denied - ${e.message}" }
+            (response as HttpServletResponse).sendError(HttpStatus.FORBIDDEN.value(), e.message)
+            return
+        }
+
+        chain.doFilter(request, response)
+    }
+
+    private fun validate(securityLevel: String) {
+        if (!highSecurityLevelList.contains(securityLevel) && harStrengtFortroligAdresse(pidGetter.pid()))
+            throw AccessDeniedException("Strengt fortrolig adresse krever høyt sikkerhetsnivå")
+    }
+
+    private fun harStrengtFortroligAdresse(pid: Pid): Boolean =
+        adresseService.adressebeskyttelseGradering(pid).fortrolighet == Fortrolighet.STRENG
+
+    private fun authentication(): EnrichedAuthentication =
+        SecurityContextHolder.getContext().authentication.enriched()
+
+    private companion object {
+        private const val SECURITY_LEVEL_CLAIM_KEY = "acr" // Authentication Context class Reference
+        private val highSecurityLevelList = listOf<String>("idporten-loa-high", "Level4")
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilter.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilter.kt
@@ -29,9 +29,9 @@ class SecurityLevelFilter(
 
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         try {
-            with(authentication()) {
-                if (veilederInnlogget().not())
-                    getClaim(SECURITY_LEVEL_CLAIM_KEY)?.let(::validate)
+            authentication()?.let {
+                if (it.veilederInnlogget().not())
+                    it.getClaim(SECURITY_LEVEL_CLAIM_KEY)?.let(::validate)
             }
         } catch (e: AccessDeniedException) {
             log.warn { "Access denied - ${e.message}" }
@@ -50,8 +50,8 @@ class SecurityLevelFilter(
     private fun harStrengtFortroligAdresse(pid: Pid): Boolean =
         adresseService.adressebeskyttelseGradering(pid).fortrolighet == Fortrolighet.STRENG
 
-    private fun authentication(): EnrichedAuthentication =
-        SecurityContextHolder.getContext().authentication.enriched()
+    private fun authentication(): EnrichedAuthentication? =
+        SecurityContextHolder.getContext().authentication?.enriched()
 
     private companion object {
         private const val SECURITY_LEVEL_CLAIM_KEY = "acr" // Authentication Context class Reference

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/ImpersonalAccessFilter.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/ImpersonalAccessFilter.kt
@@ -34,7 +34,7 @@ class ImpersonalAccessFilter(
                     forbidden(response as HttpServletResponse)
                     return
                 }
-            } catch (e: NotFoundException) {
+            } catch (_: NotFoundException) {
                 notFound(response as HttpServletResponse)
                 return
             }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/api/AnsattControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/api/AnsattControllerTest.kt
@@ -4,6 +4,7 @@ import no.nav.pensjon.kalkulator.ansatt.AnsattService
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.junit.jupiter.api.Test
@@ -32,6 +33,9 @@ class AnsattControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/api/PensjonsavtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/avtale/api/PensjonsavtaleControllerTest.kt
@@ -6,6 +6,7 @@ import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.mock.PensjonsavtaleFactory.pensjonsavtaler
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.intellij.lang.annotations.Language
@@ -37,6 +38,9 @@ class PensjonsavtaleControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingControllerTest.kt
@@ -6,6 +6,7 @@ import no.nav.pensjon.kalkulator.ekskludering.EkskluderingStatus
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.intellij.lang.annotations.Language
@@ -37,6 +38,9 @@ class EkskluderingControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/omstillingsstoenad/api/OmstillingsstoenadOgGjenlevendeYtelseControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/omstillingsstoenad/api/OmstillingsstoenadOgGjenlevendeYtelseControllerTest.kt
@@ -5,6 +5,7 @@ import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.omstillingsstoenad.OmstillingOgGjenlevendeYtelseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.intellij.lang.annotations.Language
@@ -37,6 +38,9 @@ class OmstillingsstoenadOgGjenlevendeYtelseControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/FremtidigInntektV2ControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/opptjening/api/FremtidigInntektV2ControllerTest.kt
@@ -6,6 +6,7 @@ import no.nav.pensjon.kalkulator.opptjening.InntektService
 import no.nav.pensjon.kalkulator.opptjening.Opptjeningstype
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.intellij.lang.annotations.Language
@@ -38,6 +39,9 @@ class FremtidigInntektV2ControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/api/PersonControllerTest.kt
@@ -5,6 +5,7 @@ import no.nav.pensjon.kalkulator.mock.PersonFactory.skiltPerson
 import no.nav.pensjon.kalkulator.person.PersonService
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.intellij.lang.annotations.Language
@@ -34,6 +35,9 @@ class PersonControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
@@ -7,6 +7,7 @@ import no.nav.pensjon.kalkulator.person.Sivilstand
 import no.nav.pensjon.kalkulator.simulering.*
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.toggle.FeatureToggleService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
@@ -48,6 +49,9 @@ class SimuleringControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/crypto/api/CryptoControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/crypto/api/CryptoControllerTest.kt
@@ -4,6 +4,7 @@ import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.crypto.PidEncryptionService
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import org.junit.jupiter.api.Test
@@ -34,6 +35,9 @@ class CryptoControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilterTest.kt
@@ -1,0 +1,117 @@
+package no.nav.pensjon.kalkulator.tech.security.ingress
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import no.nav.pensjon.kalkulator.mock.MockAuthentication
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.person.AdressebeskyttelseGradering
+import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonTarget
+import no.nav.pensjon.kalkulator.tech.representasjon.RepresentertRolle
+import no.nav.pensjon.kalkulator.tech.security.egress.EnrichedAuthentication
+import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressTokenSuppliersByService
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.context.SecurityContextImpl
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+class SecurityLevelFilterTest {
+
+    @Mock
+    private lateinit var request: HttpServletRequest
+
+    @Mock
+    private lateinit var response: HttpServletResponse
+
+    @Mock
+    private lateinit var chain: FilterChain
+
+    @Mock
+    private lateinit var adresseService: FortroligAdresseService
+
+    @Mock
+    private lateinit var pidGetter: PidGetter
+
+    @Test
+    fun `when strengt fortrolig adresse and insufficient security level then doFilter breaks filter chain`() {
+        arrangeAdresse(AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        arrangeSecurityContext("idporten-loa-substantial", RepresentertRolle.SELV) // insufficient
+
+        SecurityLevelFilter(adresseService, pidGetter).doFilter(request, response, chain)
+        verify(chain, never()).doFilter(request, response)
+    }
+
+    @Test
+    fun `when strengt fortrolig adresse and high security level then doFilter continues filter chain`() {
+        arrangeAdresse(AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        arrangeSecurityContext("idporten-loa-high", RepresentertRolle.SELV)
+
+        SecurityLevelFilter(adresseService, pidGetter).doFilter(request, response, chain)
+
+        verify(chain, times(1)).doFilter(request, response)
+    }
+
+    @Test
+    fun `when strengt fortrolig adresse and security level 4 then doFilter continues filter chain`() {
+        arrangeAdresse(AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        arrangeSecurityContext("Level4", RepresentertRolle.FULLMAKT_GIVER)
+
+        SecurityLevelFilter(adresseService, pidGetter).doFilter(request, response, chain)
+
+        verify(chain, times(1)).doFilter(request, response)
+    }
+
+    @Test
+    fun `when strengt fortrolig adresse and security level 3 then doFilter breaks filter chain`() {
+        arrangeAdresse(AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        arrangeSecurityContext("Level3", RepresentertRolle.FULLMAKT_GIVER)
+
+        SecurityLevelFilter(adresseService, pidGetter).doFilter(request, response, chain)
+
+        verify(chain, never()).doFilter(request, response)
+    }
+
+    @Test
+    fun `when fortrolig adresse and substantial security level then doFilter continues filter chain`() {
+        arrangeAdresse(AdressebeskyttelseGradering.FORTROLIG)
+        arrangeSecurityContext("idporten-loa-substantial", RepresentertRolle.SELV)
+
+        SecurityLevelFilter(adresseService, pidGetter).doFilter(request, response, chain)
+
+        verify(chain, times(1)).doFilter(request, response)
+    }
+
+    @Test
+    fun `when veileder innlogget then doFilter continues filter chain`() {
+        arrangeSecurityContext("", RepresentertRolle.UNDER_VEILEDNING)
+        SecurityLevelFilter(adresseService, pidGetter).doFilter(request, response, chain)
+        verify(chain, times(1)).doFilter(request, response)
+    }
+
+    private fun arrangeAdresse(gradering: AdressebeskyttelseGradering) {
+        `when`(adresseService.adressebeskyttelseGradering(pid)).thenReturn(gradering)
+        `when`(pidGetter.pid()).thenReturn(pid)
+    }
+
+    private companion object {
+        private fun arrangeSecurityContext(securityLevel: String, rolle: RepresentertRolle) {
+            SecurityContextHolder.setContext(
+                SecurityContextImpl(
+                    EnrichedAuthentication(
+                        initialAuth = MockAuthentication("acr", securityLevel),
+                        egressTokenSuppliersByService = EgressTokenSuppliersByService(emptyMap()),
+                        target = RepresentasjonTarget(null, rolle)
+                    )
+                )
+            )
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/status/StatusControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/status/StatusControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.kalkulator.tech.status
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
@@ -26,6 +27,9 @@ class StatusControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/toggle/api/FeatureToggleControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/toggle/api/FeatureToggleControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.kalkulator.tech.toggle.api
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.toggle.FeatureToggleService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
@@ -31,6 +32,9 @@ class FeatureToggleControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/api/TjenestepensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/api/TjenestepensjonControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.kalkulator.tjenestepensjon.api
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.tjenestepensjon.TjenestepensjonService
@@ -35,6 +36,9 @@ class TjenestepensjonControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjonsimulering/TjenestepensjonSimuleringControllerTest.kt
@@ -4,6 +4,7 @@ import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.tech.web.EgressException
@@ -39,6 +40,9 @@ class TjenestepensjonSimuleringControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ufoere/api/UfoerepensjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ufoere/api/UfoerepensjonControllerTest.kt
@@ -4,6 +4,7 @@ import no.nav.pensjon.kalkulator.mock.DateFactory
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.ufoere.Ufoeregrad
@@ -37,6 +38,9 @@ class UfoerepensjonControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/UttaksalderControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/api/UttaksalderControllerTest.kt
@@ -8,6 +8,7 @@ import no.nav.pensjon.kalkulator.simulering.Opphold
 import no.nav.pensjon.kalkulator.simulering.SimuleringType
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.uttaksalder.ImpersonalUttaksalderSpec
@@ -42,6 +43,9 @@ internal class UttaksalderControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/api/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/api/VedtakControllerTest.kt
@@ -2,8 +2,10 @@ package no.nav.pensjon.kalkulator.vedtak.api
 
 import kotlinx.coroutines.test.runTest
 import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration
+import no.nav.pensjon.kalkulator.mock.MockSecurityConfiguration.Companion.arrangeSecurityContext
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidExtractor
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.Auditor
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.fortrolig.FortroligAdresseService
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.group.GroupMembershipService
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.vedtak.*
@@ -40,6 +42,9 @@ class VedtakControllerTest {
 
     @MockitoBean
     private lateinit var pidExtractor: PidExtractor
+
+    @MockitoBean
+    private lateinit var fortroligAdresseService: FortroligAdresseService
 
     @MockitoBean
     private lateinit var groupMembershipService: GroupMembershipService


### PR DESCRIPTION
Brukere med strengt fortrolig adresse må logge inn med høyt sikkerhetsnivå (MinID er ikke tilstrekkelig).

Høyt sikkerhetsnivå er en av disse:
- idporten-loa-high
- Level4

MinID har som sikkerhetsnivå en av disse:
- idporten-loa-substantial
- Level3

Denne PR gjør at dette sjekkes i et nytt servlet-filter: `SecurityLevelFilter`.

NB: Brukere med fortrolig adresse (ikke strengt fortrolig) skal kunne bruke MinId.