### PR TITLE
Feature/pek 749 hent sivilstatus

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/api/dto/LoependeVedtakV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/api/dto/LoependeVedtakV3.kt
@@ -54,8 +54,8 @@ enum class SivilstandV3(val internalValue: Sivilstand) {
     REGISTRERT_PARTNER(Sivilstand.REGISTRERT_PARTNER),
     SEPARERT_PARTNER(Sivilstand.SEPARERT_PARTNER),
     SKILT_PARTNER(Sivilstand.SKILT_PARTNER),
-    GJENLEVENDE_PARTNER(Sivilstand.GJENLEVENDE_PARTNER);
-    // No SAMBOER in this context
+    GJENLEVENDE_PARTNER(Sivilstand.GJENLEVENDE_PARTNER),
+    SAMBOER(Sivilstand.SAMBOER);
 
     companion object {
         private val values = entries.toTypedArray()

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/api/dto/LoependeVedtakV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/api/dto/LoependeVedtakV4.kt
@@ -61,8 +61,8 @@ enum class SivilstandV4(val internalValue: Sivilstand) {
     REGISTRERT_PARTNER(Sivilstand.REGISTRERT_PARTNER),
     SEPARERT_PARTNER(Sivilstand.SEPARERT_PARTNER),
     SKILT_PARTNER(Sivilstand.SKILT_PARTNER),
-    GJENLEVENDE_PARTNER(Sivilstand.GJENLEVENDE_PARTNER);
-    // No SAMBOER in this context
+    GJENLEVENDE_PARTNER(Sivilstand.GJENLEVENDE_PARTNER),
+    SAMBOER(Sivilstand.SAMBOER);
 
     companion object {
         private val values = entries.toTypedArray()

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/dto/PenLoependeVedtakDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/dto/PenLoependeVedtakDto.kt
@@ -19,6 +19,7 @@ data class PenGjeldendeVedtakApDto(
     val grad: Int,
     val fraOgMed: LocalDate,
     val sivilstand: String,
+    val sivilstatus: String,
 )
 
 data class PenGjeldendeVedtakDto(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/map/LoependeVedtakMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/map/LoependeVedtakMapper.kt
@@ -27,7 +27,7 @@ object LoependeVedtakMapper {
             LoependeAlderspensjonDetaljer(
                 grad = it.grad,
                 fom = it.fraOgMed,
-                sivilstand = PenSivilstand.toInternalValue(it.sivilstand)
+                sivilstand = PenSivilstand.toInternalValue(it.sivilstatus)
             )
         }
 
@@ -36,7 +36,7 @@ object LoependeVedtakMapper {
             FremtidigAlderspensjonDetaljer(
                 grad = it.grad,
                 fom = it.fraOgMed,
-                sivilstand = PenSivilstand.toInternalValue(it.sivilstand)
+                sivilstand = PenSivilstand.toInternalValue(it.sivilstatus)
             )
         }
 

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/PenLoependeVedtakClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/PenLoependeVedtakClientTest.kt
@@ -149,7 +149,7 @@ class PenLoependeVedtakClientTest : WebClientTest() {
     private companion object {
         @Language("json")
         private const val VEDTAK_AP = """
-{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"UGIF"},"ufoeretrygd":null,"afpPrivat":null,"afp":null}
+{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"UGIF","sivilstatus":"UGIF"},"ufoeretrygd":null,"afpPrivat":null,"afp":null}
 """
         @Language("json")
         private const val VEDTAK_UFORE = """
@@ -157,15 +157,15 @@ class PenLoependeVedtakClientTest : WebClientTest() {
 """
         @Language("json")
         private const val VEDTAK_AP_OG_UFORE = """
-{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"GIFT"},"ufoeretrygd":{"grad":100,"fraOgMed":"2022-07-01"},"afpPrivat":null,"afp":null}
+{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"GIFT","sivilstatus":"GIFT"},"ufoeretrygd":{"grad":100,"fraOgMed":"2022-07-01"},"afpPrivat":null,"afp":null}
 """
         @Language("json")
         private const val VEDTAK_AP_OG_UFORE_OG_AFPPRIVAT = """
-{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"SKIL"},"ufoeretrygd":{"grad":100,"fraOgMed":"2022-07-01"},"afpPrivat":{"grad":100,"fraOgMed":"2022-07-01"},"afp":null}
+{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"SKIL","sivilstatus":"SKIL"},"ufoeretrygd":{"grad":100,"fraOgMed":"2022-07-01"},"afpPrivat":{"grad":100,"fraOgMed":"2022-07-01"},"afp":null}
 """
         @Language("json")
         private const val VEDTAK_AP_OG_UFORE_OG_AFPPRIVAT_OG_AFP = """
-{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"ENKE"},"ufoeretrygd":{"grad":100,"fraOgMed":"2022-07-01"},"afpPrivat":{"grad":100,"fraOgMed":"2022-07-01"},"afp":{"grad":100,"fraOgMed":"2022-07-01"}}
+{"alderspensjon":{"grad":100,"fraOgMed":"2025-10-01","sivilstand":"ENKE","sivilstatus":"ENKE"},"ufoeretrygd":{"grad":100,"fraOgMed":"2022-07-01"},"afpPrivat":{"grad":100,"fraOgMed":"2022-07-01"},"afp":{"grad":100,"fraOgMed":"2022-07-01"}}
 """
         @Language("json")
         private const val VEDTAK_INGEN = """

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/map/LoependeVedtakMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/vedtak/client/pen/map/LoependeVedtakMapperTest.kt
@@ -14,8 +14,8 @@ class LoependeVedtakMapperTest {
     @Test
     fun `Map from PEN og ignorer gammel afpOffentlig`() {
         val dto = PenLoependeVedtakDto(
-            alderspensjon = PenGjeldendeVedtakApDto(1, LocalDate.of(2021, 1, 1), sivilstand = "UGIF"),
-            alderspensjonIFremtid = PenGjeldendeVedtakApDto(3, LocalDate.of(2022, 1, 1), sivilstand = "GIFT"),
+            alderspensjon = PenGjeldendeVedtakApDto(1, LocalDate.of(2021, 1, 1), sivilstand = "UGIF", sivilstatus = "SAMB"),
+            alderspensjonIFremtid = PenGjeldendeVedtakApDto(3, LocalDate.of(2022, 1, 1), sivilstand = "GIFT", sivilstatus = "GIFT"),
             ufoeretrygd = PenGjeldendeUfoeregradDto(2, LocalDate.of(2021, 1, 1)),
             afpPrivat = PenGjeldendeVedtakDto(LocalDate.of(2021, 1, 1)),
             afpOffentlig = PenGjeldendeVedtakDto(LocalDate.of(2021, 1, 1)),
@@ -25,7 +25,7 @@ class LoependeVedtakMapperTest {
 
         assertEquals(1, result.alderspensjon?.grad)
         assertEquals(LocalDate.of(2021, 1, 1), result.alderspensjon?.fom)
-        assertEquals("UGIFT", result.alderspensjon?.sivilstand?.name)
+        assertEquals("SAMBOER", result.alderspensjon?.sivilstand?.name)
         assertNotNull(result.fremtidigLoependeVedtakAp)
         assertEquals(3, result.fremtidigLoependeVedtakAp?.grad)
         assertEquals(LocalDate.of(2022, 1, 1), result.fremtidigLoependeVedtakAp?.fom)


### PR DESCRIPTION
Hent sivilstatus fra Pesys med samboerinfo.

Denne kan merges etter merging Pesys PR - [https://github.com/navikt/pensjon-pen/pull/15097](https://github.com/navikt/pensjon-pen/pull/15097)
Frontend må oppdatere typeguard for å håndtere samboer-type sivilstatus/stand