### PR TITLE
PEK-957 Fix 'nærmeste fremtidige alder'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/LavesteUttaksalderService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/LavesteUttaksalderService.kt
@@ -63,9 +63,12 @@ class LavesteUttaksalderService(
     private fun teoretiskLavesteFremtidigeUttaksalder(): Alder =
         naermesteFremtidigeAlder(teoretiskLavesteUttaksalder())
 
+    /**
+     * 'Nærmeste fremtidige alder' er alder på 1. dag av neste måned.
+     */
     private fun naermesteFremtidigeAlder(alder: Alder): Alder =
         with(naavaerendeAlder()) {
-            if (this lessThan alder) alder else this plussMaaneder 1
+            if (this lessThan alder) alder else this
         }
 
     private fun teoretiskLavesteUttaksalder(): Alder = normAlderService.nedreAldersgrense()

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/LavesteUttaksalderServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/uttaksalder/LavesteUttaksalderServiceTest.kt
@@ -55,8 +55,8 @@ internal class LavesteUttaksalderServiceTest {
                 harEps = false
             )
 
-        // Uttak kan starte måneden etter fylte 64 år:
-        simuleringSpec.gradertUttak?.uttakFomAlder shouldBe Alder(aar = 64, maaneder = 1)
+        // Uttak kan starte 1. dag i måneden etter fylte 64 år:
+        simuleringSpec.gradertUttak?.uttakFomAlder shouldBe Alder(aar = 64, maaneder = 0)
         simuleringSpec.heltUttak.uttakFomAlder shouldBe Alder(aar = 67, maaneder = 0)
     }
 
@@ -74,8 +74,8 @@ internal class LavesteUttaksalderServiceTest {
                 harEps = false
             )
 
-        // Uttak kan starte måneden etter fylte 64 år:
-        simuleringSpec.heltUttak.uttakFomAlder shouldBe Alder(aar = 64, maaneder = 1)
+        // Uttak kan starte 1. dag i måneden etter fylte 64 år:
+        simuleringSpec.heltUttak.uttakFomAlder shouldBe Alder(aar = 64, maaneder = 0)
         simuleringSpec.gradertUttak shouldBe null
     }
 


### PR DESCRIPTION
'Nærmeste fremtidige alder' er alder på 1. dag av neste måned.