### PR TITLE
PEK-1044 Fix 'nærmeste fremtidige uttaksalder'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/general/Alder.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/general/Alder.kt
@@ -29,7 +29,8 @@ data class Alder(val aar: Int, val maaneder: Int) {
     companion object {
 
         fun from(foedselDato: LocalDate, dato: LocalDate): Alder {
-            val delmaanedFratrekk = if (dato.dayOfMonth - foedselDato.dayOfMonth < 0) 1 else 0
+            // NB: Hvis samme dayOfMonth regnes ikke måneden som helt fylt, dermed fratrekk 1
+            val delmaanedFratrekk = if (dato.dayOfMonth - foedselDato.dayOfMonth <= 0) 1 else 0
 
             return normalisedAlder(
                 aar = dato.year - foedselDato.year,

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/LavesteUttaksalderService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/uttaksalder/LavesteUttaksalderService.kt
@@ -40,7 +40,8 @@ class LavesteUttaksalderService(
             )
         )
 
-    private fun foedselDato(): LocalDate = personService.getPerson().foedselsdato
+    private fun foedselsdato(): LocalDate =
+        personService.getPerson().foedselsdato
 
     private fun simuleringGradertUttak(source: UttaksalderGradertUttak) =
         GradertUttak(
@@ -58,22 +59,28 @@ class LavesteUttaksalderService(
         )
 
     private fun defaultHeltUttakFremtidigFomAlderIfGradert(): Alder =
-        naermesteFremtidigeAlder(defaultHeltUttakFomAlderIfGradert())
+        alderPaaFremtidigUttaksdato(defaultHeltUttakFomAlderIfGradert())
 
     private fun teoretiskLavesteFremtidigeUttaksalder(): Alder =
-        naermesteFremtidigeAlder(teoretiskLavesteUttaksalder())
+        alderPaaFremtidigUttaksdato(teoretiskLavesteUttaksalder())
 
     /**
      * 'Nærmeste fremtidige alder' er alder på 1. dag av neste måned.
      */
-    private fun naermesteFremtidigeAlder(alder: Alder): Alder =
-        with(naavaerendeAlder()) {
-            if (this lessThan alder) alder else this
+    private fun alderPaaFremtidigUttaksdato(minimumAlder: Alder): Alder =
+        with(alderPaaNaermesteFremtidigeUttaksdato()) {
+            if (this lessThan minimumAlder) minimumAlder else this
         }
 
-    private fun teoretiskLavesteUttaksalder(): Alder = normAlderService.nedreAldersgrense()
+    private fun teoretiskLavesteUttaksalder(): Alder =
+        normAlderService.nedreAldersgrense()
 
-    private fun defaultHeltUttakFomAlderIfGradert(): Alder = normAlderService.normAlder()
+    private fun defaultHeltUttakFomAlderIfGradert(): Alder =
+        normAlderService.normAlder()
 
-    private fun naavaerendeAlder() = Alder.from(foedselDato(), todayProvider.date())
+    private fun alderPaaNaermesteFremtidigeUttaksdato() =
+        Alder.from(
+            foedselDato = foedselsdato(),
+            dato = todayProvider.date().plusMonths(1).withDayOfMonth(1)
+        )
 }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/general/AlderTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/general/AlderTest.kt
@@ -51,10 +51,11 @@ class AlderTest {
 
     @Test
     fun `test from`() {
+        // Ved lik månedsdag anses ikke måneden for helt fylt - dermed 1 måned fratrekk
         Alder.from(
             foedselDato = LocalDate.of(2001, 1, 1),
             dato = LocalDate.of(2024, 1, 1)
-        ) shouldBe Alder(aar = 23, maaneder = 0)
+        ) shouldBe Alder(aar = 22, maaneder = 11)
 
         Alder.from(
             foedselDato = LocalDate.of(1970, 2, 2),


### PR DESCRIPTION
Tidligst mulig uttak (TMU) skal beregnes som alder på nærmeste fremtidige uttaksdato etter minimumsalder.