### PR TITLE
PEK-723 Increase max-http-request-header-size

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.error.include-message=always
 server.error.include-stacktrace=${SERVER_ERROR_INCLUDE_STACKTRACE:always}
+server.max-http-request-header-size=16384
 logging.level.no.nav.pensjon.kalkulator=${PKB_LOGGING_LEVEL:DEBUG}
 spring.main.banner-mode=off
 


### PR DESCRIPTION
I et forsøk på å unngå `IllegalArgumentException: Request header is too large` økes max header-størrelse på HTTP-requester fra 8KB (Tomcat-default) til 16KB.