### PR TITLE
PEK-848 Send FNR in request body

### DIFF
--- a/src/test/kotlin/no/nav/pensjon/kalkulator/WebClientTestConfig.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/WebClientTestConfig.kt
@@ -1,0 +1,14 @@
+package no.nav.pensjon.kalkulator
+
+import no.nav.pensjon.kalkulator.tech.web.WebClientConfig
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.web.reactive.function.client.WebClient
+
+@TestConfiguration
+class WebClientTestConfig {
+
+    @Bean
+    fun webClientBuilder(): WebClient.Builder =
+        WebClient.builder().also { WebClientConfig().customize(it) }
+}


### PR DESCRIPTION
Endrer slik at fødselsnummer sendes i request body for omstillingsstønad-kall.

Ref. [etterlatte-api](https://github.com/navikt/pensjon-etterlatte-saksbehandling/tree/main/apps/etterlatte-api#api)