### PR TITLE
PEK-1168: Tillat alle applikasjoner i pensjonskalkulator NS å snakke med backend i dev

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -76,6 +76,9 @@ spec:
         - application: pensjonskalkulator-uinnlogget-dreambox
         - application: pensjonskalkulator-uinnlogget-magicbox
         - application: pensjonskalkulator-uinnlogget-sandbox
+        - application: '*'
+          namespace: pensjonskalkulator
+          cluster: dev-gcp
         - application: azure-token-generator # only in dev
           namespace: nais
         - application: tokenx-token-generator # only in dev


### PR DESCRIPTION
Tillat alle applikasjoner å snakke til pensjonskalkulator-backend i dev. Slik kan frontend lage testmiljø PR pull-request.

ref. https://github.com/navikt/pensjonskalkulator-frontend/pull/2015