### PR TITLE
Remove obsolete 'frontend client ID' property

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -169,8 +169,6 @@ spec:
       value: dev-gcp:pensjonskalkulator:tjenestepensjon-simulering
     - name: TJENESTEPENSJON_SIMULERING_URL
       value: http://tjenestepensjon-simulering
-    - name: PKB_FRONTEND_ENTRA_CLIENT_ID
-      value: 0683a6ca-6f72-458c-8367-2879103edbfc,66a20121-b743-48e5-8cdc-1037ce68d9a5,6d1669ef-61c4-4d14-98a7-0c983f4eb14a
     - name: SERVER_ERROR_INCLUDE_STACKTRACE
       value: always
     - name: AUDIT_LOG_OUTPUT

--- a/.nais/deploy-prod.yml
+++ b/.nais/deploy-prod.yml
@@ -136,8 +136,6 @@ spec:
       value: prod-gcp:pensjonskalkulator:tjenestepensjon-simulering
     - name: TJENESTEPENSJON_SIMULERING_URL
       value: http://tjenestepensjon-simulering
-    - name: PKB_FRONTEND_ENTRA_CLIENT_ID
-      value: irrelevant-when-obo-token-used
     - name: PKB_GROUP_ID_SAKSBEHANDLER
       value: 0af3955f-df85-4eb0-b5b2-45bf2c8aeb9e
     - name: PKB_GROUP_ID_EGNE_ANSATTE

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/AudienceValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/AudienceValidator.kt
@@ -8,14 +8,14 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult.failu
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult.success
 import org.springframework.security.oauth2.jwt.Jwt
 
-class AudienceValidator(val frontendAudiences: List<String>, val backendAudience: String) : OAuth2TokenValidator<Jwt> {
+class AudienceValidator(val thisAppAudience: String) : OAuth2TokenValidator<Jwt> {
 
     private val log = KotlinLogging.logger {}
 
     override fun validate(jwt: Jwt): OAuth2TokenValidatorResult = validate(jwt.audience)
 
     private fun validate(audiences: List<String>): OAuth2TokenValidatorResult =
-        if (frontendAudiences.any(audiences::contains) || audiences.contains(backendAudience))
+        if (audiences.contains(thisAppAudience))
             success()
         else
             "Invalid audience claim: ${audiences.joinToString()}".let {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,10 +10,6 @@ azure.openid-config.token-endpoint=${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT:https://
 token-x.issuer=${TOKEN_X_ISSUER:https://tokenx.dev-gcp.nav.cloud.nais.io}
 token-x.client.id=${TOKEN_X_CLIENT_ID:dev-gcp:pensjonskalkulator:pensjonskalkulator-backend}
 
-# Client ID of the frontend app (which is the audience in the token issued by Entra ID)
-# There are 3 frontend environments: staging, sandbox, catbox
-pkb.frontend.entra.client.id=${PKB_FRONTEND_ENTRA_CLIENT_ID:0683a6ca-6f72-458c-8367-2879103edbfc,66a20121-b743-48e5-8cdc-1037ce68d9a5,6d1669ef-61c4-4d14-98a7-0c983f4eb14a}
-
 springdoc.swagger-ui.disable-swagger-default-url=true
 
 management.endpoint.env.access=none


### PR DESCRIPTION
Removes obsolete 'frontend client ID' property, since it was used to validate ID-porten tokens, but now only TokenX and Entra tokens are accepted