### PR TITLE
PEK-1325 Add kap.19-gjenlevendetillegg to simulering response

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/SimulertAlderspensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/SimulertAlderspensjon.kt
@@ -18,6 +18,7 @@ data class SimulertAlderspensjon(
     val grunnpensjon: Int?,
     val tilleggspensjon: Int?,
     val pensjonstillegg: Int?,
-    val skjermingstillegg: Int?
+    val skjermingstillegg: Int?,
+    val kapittel19Gjenlevendetillegg: Int?
 )
 

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/PersonligSimuleringResultV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/dto/PersonligSimuleringResultV8.kt
@@ -40,7 +40,8 @@ data class PersonligSimuleringAlderspensjonResultV8(
     val grunnpensjon: Int? = null,
     val tilleggspensjon: Int? = null,
     val pensjonstillegg: Int? = null,
-    val skjermingstillegg: Int? = null
+    val skjermingstillegg: Int? = null,
+    val kapittel19Gjenlevendetillegg: Int? = null
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8.kt
@@ -10,17 +10,18 @@ import java.time.LocalDate
 
 /**
  * Maps between data transfer objects (DTOs) and domain objects related to simulering.
- * The DTOs are specified by version 6 of the API offered to clients.
+ * The DTOs are specified by version 8 of the API offered to clients.
  */
 object PersonligSimuleringExtendedResultMapperV8 {
 
     fun extendedResultV8(source: SimuleringResult, foedselsdato: LocalDate) =
         PersonligSimuleringResultV8(
-            alderspensjon = source.alderspensjon.map(::alderspensjon).let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) },
+            alderspensjon = source.alderspensjon.map(::alderspensjon)
+                .let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) },
             alderspensjonMaanedligVedEndring = maanedligPensjon(source.alderspensjonMaanedsbeloep),
             pre2025OffentligAfp = source.pre2025OffentligAfp?.let(::pre2025OffentligAfp),
             afpPrivat = source.afpPrivat.map(::privatAfp).let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) },
-            afpOffentlig = source.afpOffentlig.map(::offentligAfp),
+            afpOffentlig = source.afpOffentlig.map(::livsvarigOffentligAfp),
             vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving),
             harForLiteTrygdetid = source.harForLiteTrygdetid,
             trygdetid = source.trygdetid,
@@ -46,7 +47,8 @@ object PersonligSimuleringExtendedResultMapperV8 {
             grunnpensjon = source.grunnpensjon,
             tilleggspensjon = source.tilleggspensjon,
             pensjonstillegg = source.pensjonstillegg,
-            skjermingstillegg = source.skjermingstillegg
+            skjermingstillegg = source.skjermingstillegg,
+            kapittel19Gjenlevendetillegg = source.kapittel19Gjenlevendetillegg
         )
 
     private fun maanedligPensjon(source: AlderspensjonMaanedsbeloep?) =
@@ -74,10 +76,21 @@ object PersonligSimuleringExtendedResultMapperV8 {
         )
 
     private fun privatAfp(source: SimulertAfpPrivat) =
-        PersonligSimuleringAfpPrivatResultV8(alder = source.alder, beloep = source.beloep, kompensasjonstillegg = source.kompensasjonstillegg, kronetillegg = source.kronetillegg, livsvarig = source.livsvarig, maanedligBeloep = source.maanedligBeloep)
+        PersonligSimuleringAfpPrivatResultV8(
+            alder = source.alder,
+            beloep = source.beloep,
+            kompensasjonstillegg = source.kompensasjonstillegg,
+            kronetillegg = source.kronetillegg,
+            livsvarig = source.livsvarig,
+            maanedligBeloep = source.maanedligBeloep
+        )
 
-    private fun offentligAfp(source: SimulertAfpOffentlig) =
-        PersonligSimuleringAarligPensjonResultV8(alder = source.alder, beloep = source.beloep, maanedligBeloep = source.maanedligBeloep)
+    private fun livsvarigOffentligAfp(source: SimulertAfpOffentlig) =
+        PersonligSimuleringAarligPensjonResultV8(
+            alder = source.alder,
+            beloep = source.beloep,
+            maanedligBeloep = source.maanedligBeloep
+        )
 
     private fun vilkaarsproeving(source: Vilkaarsproeving) =
         PersonligSimuleringVilkaarsproevingResultV8(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/dto/SimulatorPersonligSimuleringResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/dto/SimulatorPersonligSimuleringResult.kt
@@ -1,7 +1,8 @@
 package no.nav.pensjon.kalkulator.simulering.client.simulator.dto
 
-// Corresponds to NavSimuleringResultV3 in pensjonssimulator
-// (and previously to SimuleringsresultatAlderspensjon1963Plus in PEN)
+/**
+ * Corresponds to NavSimuleringResultV3 in pensjonssimulator.
+ */
 data class SimulatorPersonligSimuleringResult(
     val alderspensjonListe: List<SimulatorPersonligPensjon>,
     val alderspensjonMaanedsbeloep: SimulatorPersonligMaanedsbeloep?,
@@ -15,6 +16,7 @@ data class SimulatorPersonligSimuleringResult(
     val error: SimulatorPersonligSimuleringError?
 )
 
+// pensjonssimulator: NavAlderspensjonV3
 data class SimulatorPersonligPensjon(
     val alderAar: Int,
     val beloep: Int,
@@ -33,7 +35,8 @@ data class SimulatorPersonligPensjon(
     val grunnpensjon: Int?,
     val tilleggspensjon: Int?,
     val pensjonstillegg: Int?,
-    val skjermingstillegg: Int?
+    val skjermingstillegg: Int?,
+    val kapittel19Gjenlevendetillegg: Int?
 )
 
 data class SimulatorPersonligMaanedsbeloep(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/map/SimulatorAnonymSimuleringResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/map/SimulatorAnonymSimuleringResultMapper.kt
@@ -40,7 +40,8 @@ object SimulatorAnonymSimuleringResultMapper {
             grunnpensjon = 0, // ditto
             tilleggspensjon = 0, // ditto
             pensjonstillegg = 0, // ditto
-            skjermingstillegg = 0 // ditto
+            skjermingstillegg = 0, // ditto
+            kapittel19Gjenlevendetillegg = 0 // ditto
         )
 
     private fun privatAfp(dto: SimulatorAnonymPrivatAfpPeriode) =

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/map/SimulatorPersonligSimuleringResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/map/SimulatorPersonligSimuleringResultMapper.kt
@@ -39,7 +39,8 @@ object SimulatorPersonligSimuleringResultMapper {
             grunnpensjon = dto.grunnpensjon ?: 0,
             tilleggspensjon = dto.tilleggspensjon ?: 0,
             pensjonstillegg = dto.pensjonstillegg ?: 0,
-            skjermingstillegg = dto.skjermingstillegg ?: 0
+            skjermingstillegg = dto.skjermingstillegg ?: 0,
+            kapittel19Gjenlevendetillegg = dto.kapittel19Gjenlevendetillegg ?: 0
         )
 
     private fun pre2025OffentligAfp(dto: SimulatorPre2025OffentligAfp) =

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/SimuleringServiceTest.kt
@@ -1,5 +1,11 @@
 package no.nav.pensjon.kalkulator.simulering
 
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.general.HeltUttak
 import no.nav.pensjon.kalkulator.land.Land
@@ -12,130 +18,122 @@ import no.nav.pensjon.kalkulator.person.Sivilstand
 import no.nav.pensjon.kalkulator.person.client.PersonClient
 import no.nav.pensjon.kalkulator.simulering.client.SimuleringClient
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidGetter
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDate
 
-@ExtendWith(SpringExtension::class)
-class SimuleringServiceTest {
+class SimuleringServiceTest : FunSpec({
 
-    private lateinit var service: SimuleringService
+    val pidGetter = mockk<PidGetter>().apply { every { pid() } returns pid }
 
-    @Mock
-    private lateinit var simuleringClient: SimuleringClient
-
-    @Mock
-    private lateinit var inntektService: InntektService
-
-    @Mock
-    private lateinit var personClient: PersonClient
-
-    @Mock
-    private lateinit var pidGetter: PidGetter
-
-    @BeforeEach
-    fun initialize() {
-        service = SimuleringService(simuleringClient, inntektService, personClient, pidGetter)
-        `when`(pidGetter.pid()).thenReturn(pid)
-    }
-
-    @Test
-    fun `simulerAlderspensjon uses specified inntekt and sivilstand`() {
+    test("simulerAlderspensjon uses specified inntekt and sivilstand") {
         val incomingSpec = impersonalSimuleringSpec(REGISTRERT_INNTEKT, Sivilstand.UOPPGITT)
-        `when`(simuleringClient.simulerPersonligAlderspensjon(incomingSpec, personalSpec)).thenReturn(simuleringResult)
+        val simuleringClient = arrangeSimuleringClient(incomingSpec)
+        val inntektService = mockk<InntektService>()
+        val personClient = mockk<PersonClient>()
+        val service = SimuleringService(simuleringClient, inntektService, personClient, pidGetter)
 
         val response = service.simulerPersonligAlderspensjon(incomingSpec)
 
-        assertEquals(123456, response.alderspensjon[0].beloep)
-        verifyNoInteractions(inntektService, personClient)
+        response.alderspensjon[0].beloep shouldBe 123456
+        verify { inntektService wasNot Called }
+        verify { personClient wasNot Called }
+
     }
 
-    @Test
-    fun `simulerAlderspensjon obtains registrert inntekt and sivilstand when not specified`() {
-        val incomingSpec = impersonalSimuleringSpec(null, null)
-        `when`(inntektService.sistePensjonsgivendeInntekt()).thenReturn(inntekt)
-        `when`(personClient.fetchPerson(pid, fetchFulltNavn = false)).thenReturn(person())
-        `when`(simuleringClient.simulerPersonligAlderspensjon(incomingSpec, personalSpec)).thenReturn(simuleringResult)
+    test("simulerAlderspensjon obtains registrert inntekt and sivilstand when not specified") {
+        val incomingSpec = impersonalSimuleringSpec(forventetInntekt = null, sivilstand = null)
+        val simuleringClient = arrangeSimuleringClient(incomingSpec)
+        val inntektService = arrangeInntekt()
+        val personClient = arrangePerson()
+        val service = SimuleringService(simuleringClient, inntektService, personClient, pidGetter)
 
         val response = service.simulerPersonligAlderspensjon(incomingSpec)
 
-        assertEquals(PENSJONSBELOEP, response.alderspensjon[0].beloep)
-        verify(inntektService, times(1)).sistePensjonsgivendeInntekt()
-        verify(personClient, times(1)).fetchPerson(pid, fetchFulltNavn = false)
+        response.alderspensjon[0].beloep shouldBe PENSJONSBELOEP
+        verify(exactly = 1) { inntektService.sistePensjonsgivendeInntekt() }
+        verify(exactly = 1) { personClient.fetchPerson(pid, fetchFulltNavn = false) }
     }
+})
 
-    private companion object {
-        private const val REGISTRERT_INNTEKT = 543210
-        private const val PENSJONSBELOEP = 123456
-        private val personalSpec = PersonalSimuleringSpec(pid, Sivilstand.UOPPGITT, REGISTRERT_INNTEKT)
+private const val REGISTRERT_INNTEKT = 543210
+private const val PENSJONSBELOEP = 123456
+private val personalSpec = PersonalSimuleringSpec(pid, Sivilstand.UOPPGITT, REGISTRERT_INNTEKT)
 
-        private val inntekt = Inntekt(
-            type = Opptjeningstype.SUM_PENSJONSGIVENDE_INNTEKT,
-            aar = 2023,
-            beloep = REGISTRERT_INNTEKT.toBigDecimal()
-        )
+private val inntekt = Inntekt(
+    type = Opptjeningstype.SUM_PENSJONSGIVENDE_INNTEKT,
+    aar = 2023,
+    beloep = REGISTRERT_INNTEKT.toBigDecimal()
+)
 
-        private val simuleringResult =
-            SimuleringResult(
-                alderspensjon = listOf(
-                    SimulertAlderspensjon(
-                        alder = 67,
-                        beloep = PENSJONSBELOEP,
-                        inntektspensjonBeloep = 0,
-                        garantipensjonBeloep = 0,
-                        delingstall = 0.0,
-                        pensjonBeholdningFoerUttak = 0,
-                        andelsbroekKap19 = 0.0,
-                        andelsbroekKap20 = 0.0,
-                        sluttpoengtall = 0.0,
-                        trygdetidKap19 = 0,
-                        trygdetidKap20 = 0,
-                        poengaarFoer92 = 0,
-                        poengaarEtter91 = 0,
-                        forholdstall = 0.0,
-                        grunnpensjon = 0,
-                        tilleggspensjon = 0,
-                        pensjonstillegg = 0,
-                        skjermingstillegg = 0
-                    )
-                ),
-                alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                    gradertUttak = null,
-                    heltUttak = 0
-                ),
-                afpPrivat = emptyList(),
-                afpOffentlig = emptyList(),
-                vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
-                harForLiteTrygdetid = false,
-                trygdetid = 0,
-                opptjeningGrunnlagListe = emptyList()
+private val simuleringResult =
+    SimuleringResult(
+        alderspensjon = listOf(
+            SimulertAlderspensjon(
+                alder = 67,
+                beloep = PENSJONSBELOEP,
+                inntektspensjonBeloep = 0,
+                garantipensjonBeloep = 0,
+                delingstall = 0.0,
+                pensjonBeholdningFoerUttak = 0,
+                andelsbroekKap19 = 0.0,
+                andelsbroekKap20 = 0.0,
+                sluttpoengtall = 0.0,
+                trygdetidKap19 = 0,
+                trygdetidKap20 = 0,
+                poengaarFoer92 = 0,
+                poengaarEtter91 = 0,
+                forholdstall = 0.0,
+                grunnpensjon = 0,
+                tilleggspensjon = 0,
+                pensjonstillegg = 0,
+                skjermingstillegg = 0,
+                kapittel19Gjenlevendetillegg = 0
             )
+        ),
+        alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
+            gradertUttak = null,
+            heltUttak = 0
+        ),
+        afpPrivat = emptyList(),
+        afpOffentlig = emptyList(),
+        vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+        harForLiteTrygdetid = false,
+        trygdetid = 0,
+        opptjeningGrunnlagListe = emptyList()
+    )
 
-        private fun impersonalSimuleringSpec(forventetInntekt: Int?, sivilstand: Sivilstand?) =
-            ImpersonalSimuleringSpec(
-                simuleringType = SimuleringType.ALDERSPENSJON,
-                sivilstand = sivilstand,
-                eps = Eps(harInntektOver2G = false, harPensjon = false),
-                forventetAarligInntektFoerUttak = forventetInntekt,
-                heltUttak = HeltUttak(
-                    uttakFomAlder = Alder(67, 1),
-                    inntekt = null
-                ),
-                utenlandsopphold = Utenlandsopphold(
-                    periodeListe = listOf(
-                        Opphold(
-                            fom = LocalDate.of(1990, 1, 2),
-                            tom = LocalDate.of(1999, 11, 30),
-                            land = Land.AUS,
-                            arbeidet = true
-                        )
-                    )
+private fun impersonalSimuleringSpec(forventetInntekt: Int?, sivilstand: Sivilstand?) =
+    ImpersonalSimuleringSpec(
+        simuleringType = SimuleringType.ALDERSPENSJON,
+        sivilstand = sivilstand,
+        eps = Eps(harInntektOver2G = false, harPensjon = false),
+        forventetAarligInntektFoerUttak = forventetInntekt,
+        heltUttak = HeltUttak(
+            uttakFomAlder = Alder(67, 1),
+            inntekt = null
+        ),
+        utenlandsopphold = Utenlandsopphold(
+            periodeListe = listOf(
+                Opphold(
+                    fom = LocalDate.of(1990, 1, 2),
+                    tom = LocalDate.of(1999, 11, 30),
+                    land = Land.AUS,
+                    arbeidet = true
                 )
             )
+        )
+    )
+
+private fun arrangeInntekt(): InntektService =
+    mockk<InntektService>().apply {
+        every { sistePensjonsgivendeInntekt() } returns inntekt
     }
-}
+
+private fun arrangePerson(): PersonClient =
+    mockk<PersonClient>().apply {
+        every { fetchPerson(pid, fetchFulltNavn = false) } returns person()
+    }
+
+private fun arrangeSimuleringClient(incomingSpec: ImpersonalSimuleringSpec): SimuleringClient =
+    mockk<SimuleringClient>().apply {
+        every { simulerPersonligAlderspensjon(incomingSpec, personalSpec) } returns simuleringResult
+    }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/SimuleringControllerTest.kt
@@ -359,251 +359,129 @@ class SimuleringControllerTest {
         private fun simuleringsresultat(simuleringType: SimuleringType, heltUttak: Boolean = true) =
             when (simuleringType) {
                 SimuleringType.ALDERSPENSJON -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
                     afpPrivat = emptyList(),
                     afpOffentlig = emptyList(),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
 
                 SimuleringType.PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
-                    afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 22056, kompensasjonstillegg = 123, kronetillegg = 5, livsvarig = 93, maanedligBeloep = 1900)),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
+                    afpPrivat = listOf(privatAfp()),
                     afpOffentlig = emptyList(),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
 
                 SimuleringType.ALDERSPENSJON_MED_AFP_PRIVAT -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
-                    afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 22056, kompensasjonstillegg = 123, kronetillegg = 5, livsvarig = 93, maanedligBeloep = 1900)),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
+                    afpPrivat = listOf(privatAfp()),
                     afpOffentlig = emptyList(),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
 
                 SimuleringType.ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
                     afpPrivat = emptyList(),
-                    afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 22056, maanedligBeloep = 1900)),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    afpOffentlig = listOf(livsvarigOffentligAfp()),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
 
                 SimuleringType.ENDRING_ALDERSPENSJON -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
                     afpPrivat = emptyList(),
                     afpOffentlig = emptyList(),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
 
                 SimuleringType.ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
-                    afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 22056, kompensasjonstillegg = 123, kronetillegg = 5, livsvarig = 93, maanedligBeloep = 1900)),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
+                    afpPrivat = listOf(privatAfp()),
                     afpOffentlig = emptyList(),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
 
                 SimuleringType.ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG -> SimuleringResult(
-                    alderspensjon = listOf(
-                        SimulertAlderspensjon(
-                            alder = 67,
-                            beloep = PENSJONSBELOEP,
-                            inntektspensjonBeloep = 0,
-                            garantipensjonBeloep = 0,
-                            delingstall = 0.0,
-                            pensjonBeholdningFoerUttak = 0,
-                            andelsbroekKap19 = 0.0,
-                            andelsbroekKap20 = 0.0,
-                            sluttpoengtall = 0.0,
-                            trygdetidKap19 = 0,
-                            trygdetidKap20 = 0,
-                            poengaarFoer92 = 0,
-                            poengaarEtter91 = 0,
-                            forholdstall = 0.0,
-                            grunnpensjon = 0,
-                            tilleggspensjon = 0,
-                            pensjonstillegg = 0,
-                            skjermingstillegg = 0
-                        )
-                    ),
-                    alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                        gradertUttak = if (heltUttak) null else 0,
-                        heltUttak = 0
-                    ),
+                    alderspensjon = listOf(alderspensjon()),
+                    alderspensjonMaanedsbeloep = maanedsbeloep(heltUttak),
                     afpPrivat = emptyList(),
-                    afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 22056, maanedligBeloep = 1900)),
-                    vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                    afpOffentlig = listOf(livsvarigOffentligAfp()),
+                    vilkaarsproeving = vilkaarsproeving(),
                     harForLiteTrygdetid = false,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 )
             }
 
-        private fun conflict() = EgressException(message = "", statusCode = HttpStatus.CONFLICT)
+        private fun alderspensjon() =
+            SimulertAlderspensjon(
+                alder = 67,
+                beloep = PENSJONSBELOEP,
+                inntektspensjonBeloep = 0,
+                garantipensjonBeloep = 0,
+                delingstall = 0.0,
+                pensjonBeholdningFoerUttak = 0,
+                andelsbroekKap19 = 0.0,
+                andelsbroekKap20 = 0.0,
+                sluttpoengtall = 0.0,
+                trygdetidKap19 = 0,
+                trygdetidKap20 = 0,
+                poengaarFoer92 = 0,
+                poengaarEtter91 = 0,
+                forholdstall = 0.0,
+                grunnpensjon = 0,
+                tilleggspensjon = 0,
+                pensjonstillegg = 0,
+                skjermingstillegg = 0,
+                kapittel19Gjenlevendetillegg = 0
+            )
+
+        private fun maanedsbeloep(heltUttak: Boolean) =
+            AlderspensjonMaanedsbeloep(
+                gradertUttak = if (heltUttak) null else 0,
+                heltUttak = 0
+            )
+
+        private fun livsvarigOffentligAfp() =
+            SimulertAfpOffentlig(alder = 67, beloep = 22056, maanedligBeloep = 1900)
+
+        private fun privatAfp() =
+            SimulertAfpPrivat(
+                alder = 67,
+                beloep = 22056,
+                kompensasjonstillegg = 123,
+                kronetillegg = 5,
+                livsvarig = 93,
+                maanedligBeloep = 1900
+            )
+
+        private fun vilkaarsproeving() =
+            Vilkaarsproeving(innvilget = true, alternativ = null)
+
+        private fun conflict() =
+            EgressException(message = "", statusCode = HttpStatus.CONFLICT)
     }
 }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8Test.kt
@@ -1,16 +1,16 @@
 package no.nav.pensjon.kalkulator.simulering.api.map
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import no.nav.pensjon.kalkulator.simulering.*
 import no.nav.pensjon.kalkulator.simulering.api.dto.*
-import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-class PersonligSimuleringExtendedResultMapperV8Test{
-    @Test
-    fun `extendedResultV8 maps domain to V8 DTO`() {
+class PersonligSimuleringExtendedResultMapperV8Test : FunSpec({
+
+    test("extendedResultV8 maps domain to V8 DTO") {
         PersonligSimuleringExtendedResultMapperV8.extendedResultV8(
-            SimuleringResult(
+            source = SimuleringResult(
                 alderspensjon = listOf(
                     SimulertAlderspensjon(
                         alder = 67,
@@ -30,11 +30,21 @@ class PersonligSimuleringExtendedResultMapperV8Test{
                         grunnpensjon = 55810,
                         tilleggspensjon = 134641,
                         pensjonstillegg = -70243,
-                        skjermingstillegg = 0
+                        skjermingstillegg = 14,
+                        kapittel19Gjenlevendetillegg = 15
                     )
                 ),
                 alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
-                afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
+                afpPrivat = listOf(
+                    SimulertAfpPrivat(
+                        alder = 67,
+                        beloep = 12000,
+                        kompensasjonstillegg = 123,
+                        kronetillegg = 69,
+                        livsvarig = 321,
+                        maanedligBeloep = 1000
+                    )
+                ),
                 afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
                 vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
                 harForLiteTrygdetid = true,
@@ -43,7 +53,8 @@ class PersonligSimuleringExtendedResultMapperV8Test{
                     SimulertOpptjeningGrunnlag(aar = 2001, pensjonsgivendeInntektBeloep = 501000),
                     SimulertOpptjeningGrunnlag(aar = 2002, pensjonsgivendeInntektBeloep = 502000)
                 )
-            ), LocalDate.now().minusYears(67).minusMonths(1)
+            ),
+            foedselsdato = LocalDate.of(1963, 1, 1)
         ) shouldBe PersonligSimuleringResultV8(
             alderspensjon = listOf(
                 PersonligSimuleringAlderspensjonResultV8(
@@ -64,15 +75,31 @@ class PersonligSimuleringExtendedResultMapperV8Test{
                     grunnpensjon = 55810,
                     tilleggspensjon = 134641,
                     pensjonstillegg = -70243,
-                    skjermingstillegg = 0
+                    skjermingstillegg = 14,
+                    kapittel19Gjenlevendetillegg = 15
                 )
             ),
             alderspensjonMaanedligVedEndring = PersonligSimuleringMaanedligPensjonResultV8(
                 gradertUttakMaanedligBeloep = 6,
                 heltUttakMaanedligBeloep = 7
             ),
-            afpPrivat = listOf(PersonligSimuleringAfpPrivatResultV8(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
-            afpOffentlig = listOf(PersonligSimuleringAarligPensjonResultV8(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+            afpPrivat = listOf(
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
+            ),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
             vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
             harForLiteTrygdetid = true,
             trygdetid = 10,
@@ -82,4 +109,4 @@ class PersonligSimuleringExtendedResultMapperV8Test{
             )
         )
     }
-}
+})

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8Test.kt
@@ -1,40 +1,19 @@
 package no.nav.pensjon.kalkulator.simulering.api.map
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import no.nav.pensjon.kalkulator.simulering.*
 import no.nav.pensjon.kalkulator.simulering.api.dto.*
-import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-class PersonligSimuleringResultMapperV8Test{
-    @Test
-    fun `resultatV8 maps domain to V8 DTO`() {
+class PersonligSimuleringResultMapperV8Test : FunSpec({
+
+    test("resultV8 maps domain to V8 DTO") {
         PersonligSimuleringResultMapperV8.resultV8(
             SimuleringResult(
-                alderspensjon = listOf(
-                    SimulertAlderspensjon(
-                        alder = 67,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    )
-                ),
+                alderspensjon = listOf(alderspensjon(alder = 67, beloep = 123456)),
                 alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
-                afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
+                afpPrivat = listOf(privatAfp(alder = 67, beloep = 12000)),
                 afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
                 vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
                 harForLiteTrygdetid = true,
@@ -60,8 +39,23 @@ class PersonligSimuleringResultMapperV8Test{
                 gradertUttakMaanedligBeloep = 6,
                 heltUttakMaanedligBeloep = 7
             ),
-            afpPrivat = listOf(PersonligSimuleringAfpPrivatResultV8(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
-            afpOffentlig = listOf(PersonligSimuleringAarligPensjonResultV8(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+            afpPrivat = listOf(
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
+            ),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
             vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
             harForLiteTrygdetid = true,
             trygdetid = null,
@@ -69,74 +63,16 @@ class PersonligSimuleringResultMapperV8Test{
         )
     }
 
-    @Test
-    fun `resultatV8 ignores alderspensjon with age 0 when mapping domain to V8 DTO`() {
+    test("resultV8 ignores alderspensjon with age 0 when mapping domain to V8 DTO") {
         PersonligSimuleringResultMapperV8.resultV8(
             SimuleringResult(
                 alderspensjon = listOf(
-                    SimulertAlderspensjon(
-                        alder = 67,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
-                    SimulertAlderspensjon(
-                        alder = 68,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
-                    SimulertAlderspensjon(
-                        alder = 0,
-                        beloep = 1,
-                        inntektspensjonBeloep = 2,
-                        garantipensjonBeloep = 3,
-                        delingstall = 4.5,
-                        pensjonBeholdningFoerUttak = 6,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    )
+                    alderspensjon(alder = 67, beloep = 123456),
+                    alderspensjon(alder = 68, beloep = 123456),
+                    alderspensjon(alder = 0, beloep = 1)
                 ),
                 alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
-                afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
+                afpPrivat = listOf(privatAfp(alder = 67, beloep = 12000)),
                 afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
                 vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
                 harForLiteTrygdetid = true,
@@ -170,8 +106,23 @@ class PersonligSimuleringResultMapperV8Test{
                 gradertUttakMaanedligBeloep = 6,
                 heltUttakMaanedligBeloep = 7
             ),
-            afpPrivat = listOf(PersonligSimuleringAfpPrivatResultV8(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
-            afpOffentlig = listOf(PersonligSimuleringAarligPensjonResultV8(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+            afpPrivat = listOf(
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
+            ),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
             vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
             harForLiteTrygdetid = true,
             trygdetid = null,
@@ -179,74 +130,16 @@ class PersonligSimuleringResultMapperV8Test{
         )
     }
 
-    @Test
-    fun `resultatV8 assigns 0 age to current age and adds it to the list, when mapping domain to V8 DTO`() {
+    test("resultV8 assigns 0 age to current age and adds it to the list, when mapping domain to V8 DTO") {
         PersonligSimuleringResultMapperV8.resultV8(
             SimuleringResult(
                 alderspensjon = listOf(
-                    SimulertAlderspensjon(
-                        alder = 68,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
-                    SimulertAlderspensjon(
-                        alder = 69,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
-                    SimulertAlderspensjon(
-                        alder = 0,
-                        beloep = 1,
-                        inntektspensjonBeloep = 2,
-                        garantipensjonBeloep = 3,
-                        delingstall = 4.5,
-                        pensjonBeholdningFoerUttak = 6,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    )
+                    alderspensjon(alder = 68, beloep = 123456),
+                    alderspensjon(alder = 69, beloep = 123456),
+                    alderspensjon(alder = 0, beloep = 1)
                 ),
                 alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
-                afpPrivat = listOf(SimulertAfpPrivat(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
+                afpPrivat = listOf(privatAfp(alder = 67, beloep = 12000)),
                 afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
                 vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
                 harForLiteTrygdetid = true,
@@ -288,8 +181,23 @@ class PersonligSimuleringResultMapperV8Test{
                 gradertUttakMaanedligBeloep = 6,
                 heltUttakMaanedligBeloep = 7
             ),
-            afpPrivat = listOf(PersonligSimuleringAfpPrivatResultV8(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)),
-            afpOffentlig = listOf(PersonligSimuleringAarligPensjonResultV8(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+            afpPrivat = listOf(
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
+            ),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
             vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
             harForLiteTrygdetid = true,
             trygdetid = null,
@@ -297,38 +205,16 @@ class PersonligSimuleringResultMapperV8Test{
         )
     }
 
-    @Test
-    fun `resultatV8 filters away Afp Privat with age 0 when mapping domain to V8 DTO`() {
+    test("resultV8 filters away Afp Privat with age 0 when mapping domain to V8 DTO") {
         PersonligSimuleringResultMapperV8.resultV8(
             SimuleringResult(
-                alderspensjon = listOf(
-                    SimulertAlderspensjon(
-                        alder = 67,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
-                ),
+                alderspensjon = listOf(alderspensjon(alder = 67, beloep = 123456)),
                 alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
                 afpPrivat = listOf(
-                    SimulertAfpPrivat(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                    SimulertAfpPrivat(alder = 68, beloep = 13000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                    SimulertAfpPrivat(alder = 0, beloep = 14000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                    ),
+                    privatAfp(alder = 67, beloep = 12000),
+                    privatAfp(alder = 68, beloep = 13000),
+                    privatAfp(alder = 0, beloep = 14000)
+                ),
                 afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
                 vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
                 harForLiteTrygdetid = true,
@@ -355,10 +241,30 @@ class PersonligSimuleringResultMapperV8Test{
                 heltUttakMaanedligBeloep = 7
             ),
             afpPrivat = listOf(
-                PersonligSimuleringAfpPrivatResultV8(alder = 67, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                PersonligSimuleringAfpPrivatResultV8(alder = 68, beloep = 13000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                ),
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 68,
+                    beloep = 13000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
             ),
-            afpOffentlig = listOf(PersonligSimuleringAarligPensjonResultV8(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
             vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
             harForLiteTrygdetid = true,
             trygdetid = null,
@@ -366,37 +272,15 @@ class PersonligSimuleringResultMapperV8Test{
         )
     }
 
-    @Test
-    fun `resultatV8 assigns Afp Privat at 0 age to current age and adds it to the list, when mapping domain to V8 DTO`() {
+    test("resultV8 assigns Afp Privat at 0 age to current age and adds it to the list, when mapping domain to V8 DTO") {
         PersonligSimuleringResultMapperV8.resultV8(
             SimuleringResult(
-                alderspensjon = listOf(
-                    SimulertAlderspensjon(
-                        alder = 67,
-                        beloep = 123456,
-                        inntektspensjonBeloep = 1,
-                        garantipensjonBeloep = 2,
-                        delingstall = 3.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
-                ),
+                alderspensjon = listOf(alderspensjon(alder = 67, beloep = 123456)),
                 alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
                 afpPrivat = listOf(
-                    SimulertAfpPrivat(alder = 68, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                    SimulertAfpPrivat(alder = 69, beloep = 13000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                    SimulertAfpPrivat(alder = 0, beloep = 14000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
+                    privatAfp(alder = 68, beloep = 12000),
+                    privatAfp(alder = 69, beloep = 13000),
+                    privatAfp(alder = 0, beloep = 14000)
                 ),
                 afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
                 vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
@@ -436,15 +320,75 @@ class PersonligSimuleringResultMapperV8Test{
                 heltUttakMaanedligBeloep = 7
             ),
             afpPrivat = listOf(
-                PersonligSimuleringAfpPrivatResultV8(alder = 67, beloep = 14000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                PersonligSimuleringAfpPrivatResultV8(alder = 68, beloep = 12000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000),
-                PersonligSimuleringAfpPrivatResultV8(alder = 69, beloep = 13000, kompensasjonstillegg = 123, kronetillegg = 69, livsvarig = 321, maanedligBeloep = 1000)
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 67,
+                    beloep = 14000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                ),
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 68,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                ),
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 69,
+                    beloep = 13000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
             ),
-            afpOffentlig = listOf(PersonligSimuleringAarligPensjonResultV8(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
             vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
             harForLiteTrygdetid = true,
             trygdetid = null,
             opptjeningGrunnlagListe = null
         )
     }
-}
+})
+
+private fun alderspensjon(alder: Int, beloep: Int) =
+    SimulertAlderspensjon(
+        alder,
+        beloep,
+        inntektspensjonBeloep = 1,
+        garantipensjonBeloep = 2,
+        delingstall = 3.4,
+        pensjonBeholdningFoerUttak = 5,
+        andelsbroekKap19 = 0.6,
+        andelsbroekKap20 = 0.4,
+        sluttpoengtall = 5.11,
+        trygdetidKap19 = 40,
+        trygdetidKap20 = 40,
+        poengaarFoer92 = 13,
+        poengaarEtter91 = 27,
+        forholdstall = 0.971,
+        grunnpensjon = 55810,
+        tilleggspensjon = 134641,
+        pensjonstillegg = -70243,
+        skjermingstillegg = 14,
+        kapittel19Gjenlevendetillegg = 15
+    )
+
+private fun privatAfp(alder: Int, beloep: Int) =
+    SimulertAfpPrivat(
+        alder,
+        beloep,
+        kompensasjonstillegg = 123,
+        kronetillegg = 69,
+        livsvarig = 321,
+        maanedligBeloep = 1000
+    )

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/PensjonssimulatorSimuleringClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/PensjonssimulatorSimuleringClientTest.kt
@@ -105,7 +105,6 @@ class PensjonssimulatorSimuleringClientTest : FunSpec({
         }
     }
 
-    //Unstable test (the body is sometimes from previous test)
     test("simulerPersonligAlderspensjon sends request body with gradert uttak when specified") {
         server!!.arrangeOkJsonResponse(ALTERNATIV_PENSJON)
 
@@ -224,7 +223,8 @@ private fun alderspensjon(alder: Int, beloep: Int) =
         grunnpensjon = 0,
         tilleggspensjon = 0,
         pensjonstillegg = 0,
-        skjermingstillegg = 0
+        skjermingstillegg = 0,
+        kapittel19Gjenlevendetillegg = 0
     )
 
 private object PensjonssimulatorSimuleringClientTestObjects {

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/map/SimulatorPersonligSimuleringResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/client/simulator/map/SimulatorPersonligSimuleringResultMapperTest.kt
@@ -1,92 +1,19 @@
 package no.nav.pensjon.kalkulator.simulering.client.simulator.map
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.simulering.*
 import no.nav.pensjon.kalkulator.simulering.client.simulator.dto.*
-import org.junit.jupiter.api.Test
 
-class SimulatorPersonligSimuleringResultMapperTest {
+class SimulatorPersonligSimuleringResultMapperTest : FunSpec({
 
-    @Test
-    fun `fromDto maps simulator-specific data transfer object to domain object`() {
-        SimulatorPersonligSimuleringResultMapper.fromDto(
-            SimulatorPersonligSimuleringResult(
-                alderspensjonListe = emptyList(),
-                alderspensjonMaanedsbeloep = SimulatorPersonligMaanedsbeloep(
-                    gradertUttakBeloep = null,
-                    heltUttakBeloep = 0
-                ),
-                pre2025OffentligAfp = null,
-                privatAfpListe = emptyList(),
-                livsvarigOffentligAfpListe = emptyList(),
-                vilkaarsproeving = SimulatorPersonligVilkaarsproeving(
-                    vilkaarErOppfylt = false,
-                    alternativ = SimulatorPersonligAlternativ(
-                        gradertUttakAlder = null,
-                        uttaksgrad = null,
-                        heltUttakAlder = SimulatorPersonligAlder(aar = 65, maaneder = 4)
-                    )
-                ),
-                tilstrekkeligTrygdetidForGarantipensjon = false,
-                trygdetid = 10,
-                opptjeningGrunnlagListe = listOf(
-                    SimulatorPersonligOpptjeningGrunnlag(aar = 2001, pensjonsgivendeInntektBeloep = 123000)
-                ),
-                error = null
-            )
-        ) shouldBe SimuleringResult(
-            alderspensjon = emptyList(),
-            alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
-                gradertUttak = null,
-                heltUttak = 0
-            ),
-            afpPrivat = emptyList(),
-            afpOffentlig = emptyList(),
-            vilkaarsproeving = Vilkaarsproeving(
-                innvilget = false,
-                alternativ = Alternativ(
-                    gradertUttakAlder = null,
-                    uttakGrad = null,
-                    heltUttakAlder = Alder(aar = 65, maaneder = 4)
-                )
-            ),
-            harForLiteTrygdetid = true,
-            trygdetid = 10,
-            opptjeningGrunnlagListe = listOf(
-                SimulertOpptjeningGrunnlag(aar = 2001, pensjonsgivendeInntektBeloep = 123000)
-            )
-        )
-    }
-
-    @Test
-    fun `0 alder beholdes i listen`() {
+    test("fromDto maps simulator-specific data transfer object to domain object") {
         SimulatorPersonligSimuleringResultMapper.fromDto(
             SimulatorPersonligSimuleringResult(
                 alderspensjonListe = listOf(
-                    pensjonDto(alderAar = 100),
-                    pensjonDto(alderAar = 50),
-                    pensjonDto(alderAar = 75),
-                    SimulatorPersonligPensjon(
-                        alderAar = 0,
-                        beloep = 1,
-                        inntektspensjon = 2,
-                        garantipensjon = 3,
-                        delingstall = 0.4,
-                        pensjonBeholdningFoerUttak = 5,
-                        andelsbroekKap19 = 0.6,
-                        andelsbroekKap20 = 0.4,
-                        sluttpoengtall = 5.11,
-                        trygdetidKap19 = 40,
-                        trygdetidKap20 = 40,
-                        poengaarFoer92 = 13,
-                        poengaarEtter91 = 27,
-                        forholdstall = 0.971,
-                        grunnpensjon = 55810,
-                        tilleggspensjon = 134641,
-                        pensjonstillegg = -70243,
-                        skjermingstillegg = 0
-                    ),
+                    pensjonDto(alderAar = 50, beloep = 1001),
+                    pensjonDto(alderAar = 75, beloep = 1001)
                 ),
                 alderspensjonMaanedsbeloep = SimulatorPersonligMaanedsbeloep(
                     gradertUttakBeloep = null,
@@ -112,31 +39,13 @@ class SimulatorPersonligSimuleringResultMapperTest {
             )
         ) shouldBe SimuleringResult(
             alderspensjon = listOf(
-                alderspensjon(alderAar = 100),
                 alderspensjon(alderAar = 50),
-                alderspensjon(alderAar = 75),
-                SimulertAlderspensjon(
-                    alder = 0,
-                    beloep = 1,
-                    inntektspensjonBeloep = 2,
-                    garantipensjonBeloep = 3,
-                    delingstall = 0.4,
-                    pensjonBeholdningFoerUttak = 5,
-                    andelsbroekKap19 = 0.6,
-                    andelsbroekKap20 = 0.4,
-                    sluttpoengtall = 5.11,
-                    trygdetidKap19 = 40,
-                    trygdetidKap20 = 40,
-                    poengaarFoer92 = 13,
-                    poengaarEtter91 = 27,
-                    forholdstall = 0.971,
-                    grunnpensjon = 55810,
-                    tilleggspensjon = 134641,
-                    pensjonstillegg = -70243,
-                    skjermingstillegg = 0
-                ),
+                alderspensjon(alderAar = 75)
             ),
-            alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = null, heltUttak = 0),
+            alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(
+                gradertUttak = null,
+                heltUttak = 0
+            ),
             afpPrivat = emptyList(),
             afpOffentlig = emptyList(),
             vilkaarsproeving = Vilkaarsproeving(
@@ -155,49 +64,69 @@ class SimulatorPersonligSimuleringResultMapperTest {
         )
     }
 
-    private companion object {
-        private fun pensjonDto(alderAar: Int) =
-            SimulatorPersonligPensjon(
-                alderAar,
-                beloep = 1001,
-                inntektspensjon = 2001,
-                garantipensjon = 3001,
-                delingstall = 0.51,
-                pensjonBeholdningFoerUttak = 4001,
-                andelsbroekKap19 = 0.6,
-                andelsbroekKap20 = 0.4,
-                sluttpoengtall = 5.11,
-                trygdetidKap19 = 40,
-                trygdetidKap20 = 40,
-                poengaarFoer92 = 13,
-                poengaarEtter91 = 27,
-                forholdstall = 0.971,
-                grunnpensjon = 50810,
-                tilleggspensjon = 134641,
-                pensjonstillegg = 61243,
-                skjermingstillegg = 0
+    test("0 alder beholdes i listen") {
+        SimulatorPersonligSimuleringResultMapper.fromDto(
+            SimulatorPersonligSimuleringResult(
+                alderspensjonListe = listOf(
+                    pensjonDto(alderAar = 50, beloep = 1001),
+                    pensjonDto(alderAar = 0, beloep = 1)
+                ),
+                alderspensjonMaanedsbeloep = null,
+                pre2025OffentligAfp = null,
+                privatAfpListe = emptyList(),
+                livsvarigOffentligAfpListe = emptyList(),
+                vilkaarsproeving = null,
+                tilstrekkeligTrygdetidForGarantipensjon = false,
+                trygdetid = 10,
+                opptjeningGrunnlagListe = emptyList(),
+                error = null
             )
-
-        private fun alderspensjon(alderAar: Int) =
-            SimulertAlderspensjon(
-                alderAar,
-                beloep = 1001,
-                inntektspensjonBeloep = 2001,
-                garantipensjonBeloep = 3001,
-                delingstall = 0.51,
-                pensjonBeholdningFoerUttak = 4001,
-                andelsbroekKap19 = 0.6,
-                andelsbroekKap20 = 0.4,
-                sluttpoengtall = 5.11,
-                trygdetidKap19 = 40,
-                trygdetidKap20 = 40,
-                poengaarFoer92 = 13,
-                poengaarEtter91 = 27,
-                forholdstall = 0.971,
-                grunnpensjon = 50810,
-                tilleggspensjon = 134641,
-                pensjonstillegg = 61243,
-                skjermingstillegg = 0
-            )
+        ).alderspensjon.first { it.alder == 0 }.beloep shouldBe 1
     }
-}
+})
+
+private fun pensjonDto(alderAar: Int, beloep: Int) =
+    SimulatorPersonligPensjon(
+        alderAar,
+        beloep,
+        inntektspensjon = 2001,
+        garantipensjon = 3001,
+        delingstall = 0.51,
+        pensjonBeholdningFoerUttak = 4001,
+        andelsbroekKap19 = 0.6,
+        andelsbroekKap20 = 0.4,
+        sluttpoengtall = 5.11,
+        trygdetidKap19 = 40,
+        trygdetidKap20 = 40,
+        poengaarFoer92 = 13,
+        poengaarEtter91 = 27,
+        forholdstall = 0.971,
+        grunnpensjon = 50810,
+        tilleggspensjon = 134641,
+        pensjonstillegg = 61243,
+        skjermingstillegg = 14,
+        kapittel19Gjenlevendetillegg = 15
+    )
+
+private fun alderspensjon(alderAar: Int) =
+    SimulertAlderspensjon(
+        alderAar,
+        beloep = 1001,
+        inntektspensjonBeloep = 2001,
+        garantipensjonBeloep = 3001,
+        delingstall = 0.51,
+        pensjonBeholdningFoerUttak = 4001,
+        andelsbroekKap19 = 0.6,
+        andelsbroekKap20 = 0.4,
+        sluttpoengtall = 5.11,
+        trygdetidKap19 = 40,
+        trygdetidKap20 = 40,
+        poengaarFoer92 = 13,
+        poengaarEtter91 = 27,
+        forholdstall = 0.971,
+        grunnpensjon = 50810,
+        tilleggspensjon = 134641,
+        pensjonstillegg = 61243,
+        skjermingstillegg = 14,
+        kapittel19Gjenlevendetillegg = 15
+    )


### PR DESCRIPTION
Inkluderer gjenlevendetillegg for kapittel 19-beregning i responsen for alderspensjonssimulering for innlogget kalkulator.

Pluss refaktorer enhetstester:

- Bruker Kotest og Mockk
- Funksjoner for gjentatt kode
