### PR TITLE
Feature/pek 1386 forskyvet beregning for bruker foedt samme mnd

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8.kt
@@ -4,6 +4,7 @@ import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.general.Uttaksgrad
 import no.nav.pensjon.kalkulator.simulering.*
 import no.nav.pensjon.kalkulator.simulering.api.dto.*
+import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.filtrerBortGjeldendeAlderFoerBursdag
 import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.justerAfpPrivatIInnevaerendeAarV8
 import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.justerAlderspensjonIInnevaerendeAarV8
 import java.time.LocalDate
@@ -17,10 +18,12 @@ object PersonligSimuleringExtendedResultMapperV8 {
     fun extendedResultV8(source: SimuleringResult, foedselsdato: LocalDate) =
         PersonligSimuleringResultV8(
             alderspensjon = source.alderspensjon.map(::alderspensjon)
-                .let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) },
+                .let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) }
+                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAlderspensjonResultV8::alder) },
             alderspensjonMaanedligVedEndring = maanedligPensjon(source.alderspensjonMaanedsbeloep),
             pre2025OffentligAfp = source.pre2025OffentligAfp?.let(::pre2025OffentligAfp),
-            afpPrivat = source.afpPrivat.map(::privatAfp).let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) },
+            afpPrivat = source.afpPrivat.map(::privatAfp).let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) }
+                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAfpPrivatResultV8::alder) },
             afpOffentlig = source.afpOffentlig.map(::livsvarigOffentligAfp),
             vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving),
             harForLiteTrygdetid = source.harForLiteTrygdetid,

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringExtendedResultMapperV8.kt
@@ -4,7 +4,7 @@ import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.general.Uttaksgrad
 import no.nav.pensjon.kalkulator.simulering.*
 import no.nav.pensjon.kalkulator.simulering.api.dto.*
-import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.filtrerBortGjeldendeAlderFoerBursdag
+import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.filtrerBortGjeldendeAlderFoerBursdagIInnevaerendeMaaned
 import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.justerAfpPrivatIInnevaerendeAarV8
 import no.nav.pensjon.kalkulator.simulering.api.map.PersonligSimuleringResultMapperV8.justerAlderspensjonIInnevaerendeAarV8
 import java.time.LocalDate
@@ -19,11 +19,11 @@ object PersonligSimuleringExtendedResultMapperV8 {
         PersonligSimuleringResultV8(
             alderspensjon = source.alderspensjon.map(::alderspensjon)
                 .let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) }
-                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAlderspensjonResultV8::alder) },
+                .let { filtrerBortGjeldendeAlderFoerBursdagIInnevaerendeMaaned(it, foedselsdato, PersonligSimuleringAlderspensjonResultV8::alder) },
             alderspensjonMaanedligVedEndring = maanedligPensjon(source.alderspensjonMaanedsbeloep),
             pre2025OffentligAfp = source.pre2025OffentligAfp?.let(::pre2025OffentligAfp),
             afpPrivat = source.afpPrivat.map(::privatAfp).let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) }
-                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAfpPrivatResultV8::alder) },
+                .let { filtrerBortGjeldendeAlderFoerBursdagIInnevaerendeMaaned(it, foedselsdato, PersonligSimuleringAfpPrivatResultV8::alder) },
             afpOffentlig = source.afpOffentlig.map(::livsvarigOffentligAfp),
             vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving),
             harForLiteTrygdetid = source.harForLiteTrygdetid,

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8.kt
@@ -33,7 +33,7 @@ object PersonligSimuleringResultMapperV8 {
             beloep = source.beloep
         )
 
-    private fun <T> filtrerBortGjeldendeAlderFoerBursdag(
+    fun <T> filtrerBortGjeldendeAlderFoerBursdag(
         list: List<T>,
         foedselsdato: LocalDate,
         alderExtractor: (T) -> Int

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8.kt
@@ -8,16 +8,20 @@ import java.time.LocalDate
 
 /**
  * Maps between data transfer objects (DTOs) and domain objects related to simulering.
- * The DTOs are specified by version 6 of the API offered to clients.
+ * The DTOs are specified by version 8 of the API offered to clients.
  */
 object PersonligSimuleringResultMapperV8 {
 
     fun resultV8(source: SimuleringResult, foedselsdato: LocalDate) =
         PersonligSimuleringResultV8(
-            alderspensjon = source.alderspensjon.map(::alderspensjon).let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) },
+            alderspensjon = source.alderspensjon.map(::alderspensjon)
+                .let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) }
+                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAlderspensjonResultV8::alder) },
             alderspensjonMaanedligVedEndring = maanedligPensjon(source.alderspensjonMaanedsbeloep),
             pre2025OffentligAfp = source.pre2025OffentligAfp?.let(::pre2025OffentligAfp),
-            afpPrivat = source.afpPrivat.map(::privatAfp).let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) },
+            afpPrivat = source.afpPrivat.map(::privatAfp)
+                .let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) }
+                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAfpPrivatResultV8::alder) },
             afpOffentlig = source.afpOffentlig.map(::offentligAfp),
             vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving),
             harForLiteTrygdetid = source.harForLiteTrygdetid,
@@ -28,6 +32,20 @@ object PersonligSimuleringResultMapperV8 {
             alder = source.alder,
             beloep = source.beloep
         )
+
+    private fun <T> filtrerBortGjeldendeAlderFoerBursdag(
+        list: List<T>,
+        foedselsdato: LocalDate,
+        alderExtractor: (T) -> Int
+    ): List<T> {
+        val brukerFyllerSnartAarDenneMaaneden = foedselsdato.monthValue == LocalDate.now().monthValue
+                && foedselsdato.dayOfMonth >= LocalDate.now().dayOfMonth
+        if (brukerFyllerSnartAarDenneMaaneden) {
+            val alderAarTilAaTaBort = Alder.from(foedselsdato, LocalDate.now()).aar
+            return list.filter { alderExtractor(it) != alderAarTilAaTaBort }.sortedBy(alderExtractor)
+        }
+        return list.sortedBy(alderExtractor)
+    }
 
     /**
      * Assign a pension with age 0 to the current age, or remove it from the list if the current age already exists.

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8.kt
@@ -16,12 +16,12 @@ object PersonligSimuleringResultMapperV8 {
         PersonligSimuleringResultV8(
             alderspensjon = source.alderspensjon.map(::alderspensjon)
                 .let { justerAlderspensjonIInnevaerendeAarV8(it, foedselsdato) }
-                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAlderspensjonResultV8::alder) },
+                .let { filtrerBortGjeldendeAlderFoerBursdagIInnevaerendeMaaned(it, foedselsdato, PersonligSimuleringAlderspensjonResultV8::alder) },
             alderspensjonMaanedligVedEndring = maanedligPensjon(source.alderspensjonMaanedsbeloep),
             pre2025OffentligAfp = source.pre2025OffentligAfp?.let(::pre2025OffentligAfp),
             afpPrivat = source.afpPrivat.map(::privatAfp)
                 .let { justerAfpPrivatIInnevaerendeAarV8(it, foedselsdato) }
-                .let { filtrerBortGjeldendeAlderFoerBursdag(it, foedselsdato, PersonligSimuleringAfpPrivatResultV8::alder) },
+                .let { filtrerBortGjeldendeAlderFoerBursdagIInnevaerendeMaaned(it, foedselsdato, PersonligSimuleringAfpPrivatResultV8::alder) },
             afpOffentlig = source.afpOffentlig.map(::offentligAfp),
             vilkaarsproeving = vilkaarsproeving(source.vilkaarsproeving),
             harForLiteTrygdetid = source.harForLiteTrygdetid,
@@ -33,18 +33,18 @@ object PersonligSimuleringResultMapperV8 {
             beloep = source.beloep
         )
 
-    fun <T> filtrerBortGjeldendeAlderFoerBursdag(
+    fun <T> filtrerBortGjeldendeAlderFoerBursdagIInnevaerendeMaaned(
         list: List<T>,
         foedselsdato: LocalDate,
         alderExtractor: (T) -> Int
     ): List<T> {
-        val brukerFyllerSnartAarDenneMaaneden = foedselsdato.monthValue == LocalDate.now().monthValue
-                && foedselsdato.dayOfMonth >= LocalDate.now().dayOfMonth
-        if (brukerFyllerSnartAarDenneMaaneden) {
-            val alderAarTilAaTaBort = Alder.from(foedselsdato, LocalDate.now()).aar
-            return list.filter { alderExtractor(it) != alderAarTilAaTaBort }.sortedBy(alderExtractor)
+        val naa = LocalDate.now()
+        val harBursdagSenereDenneMaaneden = foedselsdato.monthValue == naa.monthValue && foedselsdato.dayOfMonth >= naa.dayOfMonth
+        if (harBursdagSenereDenneMaaneden) {
+            val alderAarTilAaTaBort = Alder.from(foedselsdato, naa).aar
+            return list.filter { alderExtractor(it) != alderAarTilAaTaBort }
         }
-        return list.sortedBy(alderExtractor)
+        return list
     }
 
     /**

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/simulering/api/map/PersonligSimuleringResultMapperV8Test.kt
@@ -358,6 +358,85 @@ class PersonligSimuleringResultMapperV8Test : FunSpec({
             opptjeningGrunnlagListe = null
         )
     }
+
+    test("resultat V8 alderspensjons and afpPrivat liste fjerner dagens alder hvis bruker fyller aar senere i maaned") {
+        val now = LocalDate.now()
+        val foedselsdato = now.minusYears(63).plusMonths(1).withDayOfMonth(1).minusDays(1) //siste dag i måneden
+        PersonligSimuleringResultMapperV8.resultV8(
+            source = SimuleringResult(
+                alderspensjon = listOf(
+                    alderspensjon(alder = 62, beloep = 1),
+                    alderspensjon(alder = 63, beloep = 2),
+                    alderspensjon(alder = 64, beloep = 3)
+                ),
+                alderspensjonMaanedsbeloep = AlderspensjonMaanedsbeloep(gradertUttak = 6, heltUttak = 7),
+                afpPrivat = listOf(privatAfp(alder = 62, beloep = 12000),
+                    privatAfp(alder = 63, beloep = 12000), privatAfp(alder = 64, beloep = 12000)),
+                afpOffentlig = listOf(SimulertAfpOffentlig(alder = 67, beloep = 12000, maanedligBeloep = 1000)),
+                vilkaarsproeving = Vilkaarsproeving(innvilget = true, alternativ = null),
+                harForLiteTrygdetid = true,
+                trygdetid = 10,
+                opptjeningGrunnlagListe = listOf(
+                    SimulertOpptjeningGrunnlag(aar = 2001, pensjonsgivendeInntektBeloep = 501000),
+                    SimulertOpptjeningGrunnlag(aar = 2002, pensjonsgivendeInntektBeloep = 502000)
+                )
+            ),
+            foedselsdato = foedselsdato
+        ) shouldBe PersonligSimuleringResultV8(
+            alderspensjon = listOf(
+                PersonligSimuleringAlderspensjonResultV8(
+                    alder = 63,
+                    beloep = 2,
+                    inntektspensjonBeloep = null,
+                    garantipensjonBeloep = null,
+                    delingstall = null,
+                    pensjonBeholdningFoerUttakBeloep = null
+                ),
+                PersonligSimuleringAlderspensjonResultV8(
+                    alder = 64,
+                    beloep = 3,
+                    inntektspensjonBeloep = null,
+                    garantipensjonBeloep = null,
+                    delingstall = null,
+                    pensjonBeholdningFoerUttakBeloep = null
+                ),
+            ),
+            alderspensjonMaanedligVedEndring = PersonligSimuleringMaanedligPensjonResultV8(
+                gradertUttakMaanedligBeloep = 6,
+                heltUttakMaanedligBeloep = 7
+            ),
+            afpPrivat = listOf(
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 63,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                ),
+                PersonligSimuleringAfpPrivatResultV8(
+                    alder = 64,
+                    beloep = 12000,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 69,
+                    livsvarig = 321,
+                    maanedligBeloep = 1000
+                )
+            ),
+            afpOffentlig = listOf(
+                PersonligSimuleringAarligPensjonResultV8(
+                    alder = 67,
+                    beloep = 12000,
+                    maanedligBeloep = 1000
+                )
+            ),
+            vilkaarsproeving = PersonligSimuleringVilkaarsproevingResultV8(vilkaarErOppfylt = true, alternativ = null),
+            harForLiteTrygdetid = true,
+            trygdetid = null,
+            opptjeningGrunnlagListe = null
+        )
+    }
+
 })
 
 private fun alderspensjon(alder: Int, beloep: Int) =


### PR DESCRIPTION
Fjerner inneværende år fra resultatliste (AP og AFP Privat), hvis brukeren fyller år samme måneden.
Frontend takler ikke dette året og viser kolonne med tilfeldig tall på slutten.