### PR TITLE
TPP-26 Log 'person ikke funnet' as warning not error

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/EkskluderingFacade.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/EkskluderingFacade.kt
@@ -10,22 +10,21 @@ class EkskluderingFacade(
     val sakService: SakService,
     val tjenestepensjonService: TjenestepensjonService
 ) {
-    fun erEkskludert(): EkskluderingStatus =
-        ekskluderingStatus(sakService.sakStatus()) ?: annenEkskluderingStatus()
+    fun ekskluderingPgaSakEllerApoteker(): EkskluderingStatus =
+        sakEkskludering(sakStatus = sakService.sakStatus()) ?: apotekerEkskludering()
 
-    fun erEkskludertV2(): EkskluderingStatus = annenEkskluderingStatus()
-
-    fun erApotekerV1(): EkskluderingStatus = annenEkskluderingStatus()
-
-    private fun ekskluderingStatus(sakStatus: RelevantSakStatus): EkskluderingStatus? =
-        if (sakStatus.harSak)
-            EkskluderingStatus(true, EkskluderingAarsak.from(sakStatus.sakType))
-        else
-            null
-
-    private fun annenEkskluderingStatus() =
+    fun apotekerEkskludering(): EkskluderingStatus =
         if (tjenestepensjonService.erApoteker())
             EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER)
         else
             EkskluderingStatus(ekskludert = false, aarsak = EkskluderingAarsak.NONE)
+
+    private companion object {
+
+        private fun sakEkskludering(sakStatus: RelevantSakStatus): EkskluderingStatus? =
+            if (sakStatus.harSak)
+                EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.from(sakStatus.sakType))
+            else
+                null
+    }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingController.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingController.kt
@@ -11,8 +11,8 @@ import no.nav.pensjon.kalkulator.ekskludering.EkskluderingFacade
 import no.nav.pensjon.kalkulator.ekskludering.api.dto.ApotekerStatusV1
 import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingStatusV1
 import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingStatusV2
-import no.nav.pensjon.kalkulator.ekskludering.api.map.EkskluderingMapper.version1
-import no.nav.pensjon.kalkulator.ekskludering.api.map.EkskluderingMapper.version2
+import no.nav.pensjon.kalkulator.ekskludering.api.map.EkskluderingMapper.statusV1
+import no.nav.pensjon.kalkulator.ekskludering.api.map.EkskluderingMapper.statusV2
 import no.nav.pensjon.kalkulator.ekskludering.api.map.EkskluderingMapper.apotekerStatusV1
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.tech.web.EgressException
@@ -49,7 +49,7 @@ class EkskluderingController(
         log.debug { "Request for ekskludering-status" }
 
         return try {
-            version1(timed(service::erEkskludert, "erEkskludertV1"))
+            statusV1(timed(service::ekskluderingPgaSakEllerApoteker, "erEkskludertV1"))
                 .also { log.debug { "Eksludering-status respons: $it" } }
         } catch (e: EgressException) {
             handleError(e, "V1")!!
@@ -80,7 +80,7 @@ class EkskluderingController(
         log.debug { "Request for ekskludering-status" }
 
         return try {
-            version2(timed(service::erEkskludertV2, "erEkskludertV2"))
+            statusV2(timed(service::apotekerEkskludering, "erEkskludertV2"))
                 .also { log.debug { "Eksludering-status respons: $it" } }
         } catch (e: EgressException) {
             handleError(e, "V2")!!
@@ -111,7 +111,7 @@ class EkskluderingController(
         log.debug { "Request for ekskludering-status" }
 
         return try {
-            apotekerStatusV1(timed(service::erApotekerV1, "erApotekerV1"))
+            apotekerStatusV1(timed(service::apotekerEkskludering, "erApotekerV1"))
                 .also { log.debug { "Eksludering-status respons: $it" } }
         } catch (e: EgressException) {
             handleError(e, "V1")!!

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/dto/ApotekerStatusV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/dto/ApotekerStatusV1.kt
@@ -1,3 +1,4 @@
 package no.nav.pensjon.kalkulator.ekskludering.api.dto
 
+//TODO: Should not mix version numbers (ApotekerStatusV1 vs EkskluderingAarsakV2)
 data class ApotekerStatusV1(val apoteker: Boolean, val aarsak: EkskluderingAarsakV2)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/map/EkskluderingMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/map/EkskluderingMapper.kt
@@ -7,23 +7,27 @@ import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingAarsakV2
 import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingStatusV1
 import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingStatusV2
 
+/**
+ * Anti-corruption layer.
+ * Maps from internal domain to data transfer objects.
+ */
 object EkskluderingMapper {
 
-    fun version1(source: EkskluderingStatus) =
+    fun statusV1(source: EkskluderingStatus) =
         EkskluderingStatusV1(
             ekskludert = source.ekskludert,
-            aarsak = EkskluderingAarsakV1.fromInternalValue(source.aarsak)
+            aarsak = EkskluderingAarsakV1.fromInternalValue(value = source.aarsak)
         )
 
-    fun version2(source: EkskluderingStatus) =
+    fun statusV2(source: EkskluderingStatus) =
         EkskluderingStatusV2(
-            aarsak = EkskluderingAarsakV2.fromInternalValue(source.aarsak),
+            aarsak = EkskluderingAarsakV2.fromInternalValue(value = source.aarsak),
             ekskludert = source.ekskludert
         )
 
     fun apotekerStatusV1(source: EkskluderingStatus) =
         ApotekerStatusV1(
-            aarsak = EkskluderingAarsakV2.fromInternalValue(source.aarsak),
+            aarsak = EkskluderingAarsakV2.fromInternalValue(value = source.aarsak),
             apoteker = source.ekskludert
         )
 }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/EkskluderingFacadeTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/EkskluderingFacadeTest.kt
@@ -1,85 +1,63 @@
 package no.nav.pensjon.kalkulator.ekskludering
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.pensjon.kalkulator.sak.RelevantSakStatus
 import no.nav.pensjon.kalkulator.sak.SakService
 import no.nav.pensjon.kalkulator.sak.SakType
 import no.nav.pensjon.kalkulator.tjenestepensjon.TjenestepensjonService
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@ExtendWith(SpringExtension::class)
-class EkskluderingFacadeTest {
+class EkskluderingFacadeTest : FunSpec({
 
-    @Mock
-    private lateinit var sakService: SakService
-
-    @Mock
-    private lateinit var tjenestepensjonService: TjenestepensjonService
-
-    private lateinit var ekskluderingService: EkskluderingFacade
-
-    @BeforeEach
-    fun initialize() {
-        ekskluderingService = EkskluderingFacade(sakService, tjenestepensjonService)
+    test("'ekskluderingPgaSakEllerApoteker' gir normalt 'false'") {
+        EkskluderingFacade(
+            sakService = arrangeSak(type = SakType.NONE),
+            tjenestepensjonService = arrangeApoteker(erApoteker = false)
+        ).ekskluderingPgaSakEllerApoteker() shouldBe
+                EkskluderingStatus(ekskludert = false, aarsak = EkskluderingAarsak.NONE)
     }
 
-    @Test
-    fun `'erEkskludert' gir normalt 'false'`() {
-        val expected = EkskluderingStatus(false, EkskluderingAarsak.NONE)
-        `when`(sakService.sakStatus()).thenReturn(RelevantSakStatus(false, SakType.NONE))
-        `when`(tjenestepensjonService.erApoteker()).thenReturn(false)
-
-        val erEkskludert = ekskluderingService.erEkskludert()
-
-        erEkskludert shouldBe expected
+    test("'ekskluderingPgaSakEllerApoteker' gir 'true' ved gjenlevendeytelse`") {
+        EkskluderingFacade(
+            sakService = arrangeSak(type = SakType.GJENLEVENDEYTELSE),
+            tjenestepensjonService = arrangeApoteker(erApoteker = false)
+        ).ekskluderingPgaSakEllerApoteker() shouldBe
+                EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.HAR_GJENLEVENDEYTELSE)
     }
 
-    @Test
-    fun `'erEkskludert' gir 'true' ved gjenlevendeytelse`() {
-        val expected = EkskluderingStatus(true, EkskluderingAarsak.HAR_GJENLEVENDEYTELSE)
-        `when`(sakService.sakStatus()).thenReturn(RelevantSakStatus(true, SakType.GJENLEVENDEYTELSE))
-        `when`(tjenestepensjonService.erApoteker()).thenReturn(false)
-
-        val erEkskludert = ekskluderingService.erEkskludert()
-
-        erEkskludert shouldBe expected
+    test("'ekskluderingPgaSakEllerApoteker' gir 'true' for apoteker`") {
+        EkskluderingFacade(
+            sakService = arrangeSak(type = SakType.NONE),
+            tjenestepensjonService = arrangeApoteker(erApoteker = true)
+        ).ekskluderingPgaSakEllerApoteker() shouldBe
+                EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER)
     }
 
-    @Test
-    fun `'erEkskludert' gir 'true' for apoteker`() {
-        val expected = EkskluderingStatus(true, EkskluderingAarsak.ER_APOTEKER)
-        `when`(sakService.sakStatus()).thenReturn(RelevantSakStatus(false, SakType.NONE))
-        `when`(tjenestepensjonService.erApoteker()).thenReturn(true)
-
-        val erEkskludert = ekskluderingService.erEkskludert()
-
-        erEkskludert shouldBe expected
+    test("'apotekerEkskludering' gir normalt 'false'") {
+        EkskluderingFacade(
+            sakService = arrangeSak(type = SakType.NONE),
+            tjenestepensjonService = arrangeApoteker(erApoteker = false)
+        ).apotekerEkskludering() shouldBe
+                EkskluderingStatus(ekskludert = false, aarsak = EkskluderingAarsak.NONE)
     }
 
+    test("'apotekerEkskludering' gir 'true' for apoteker`") {
+        EkskluderingFacade(
+            sakService = arrangeSak(type = SakType.NONE),
+            tjenestepensjonService = arrangeApoteker(erApoteker = true)
+        ).apotekerEkskludering() shouldBe
+                EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER)
+    }
+})
 
-    @Test
-    fun `'erEkskludertV2' gir normalt 'false'`() {
-        val expected = EkskluderingStatus(false, EkskluderingAarsak.NONE)
-        `when`(tjenestepensjonService.erApoteker()).thenReturn(false)
-
-        val erEkskludert = ekskluderingService.erEkskludertV2()
-
-        erEkskludert shouldBe expected
+private fun arrangeApoteker(erApoteker: Boolean): TjenestepensjonService =
+    mockk<TjenestepensjonService>().apply {
+        every { erApoteker() } returns erApoteker
     }
 
-    @Test
-    fun `'erEkskludertV2' gir 'true' for apoteker`() {
-        val expected = EkskluderingStatus(true, EkskluderingAarsak.ER_APOTEKER)
-        `when`(tjenestepensjonService.erApoteker()).thenReturn(true)
-
-        val erEkskludert = ekskluderingService.erEkskludertV2()
-
-        erEkskludert shouldBe expected
+private fun arrangeSak(type: SakType): SakService =
+    mockk<SakService>().apply {
+        every { sakStatus() } returns RelevantSakStatus(harSak = type != SakType.NONE, sakType = type)
     }
-
-}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/EkskluderingControllerTest.kt
@@ -50,78 +50,120 @@ class EkskluderingControllerTest {
 
     @Test
     fun `'erEkskludertV1' returnerer normalt status 'OK' og JSON-respons`() {
-        val ekskluderingStatus = EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER)
-        `when`(service.erEkskludert()).thenReturn(ekskluderingStatus)
+        `when`(service.ekskluderingPgaSakEllerApoteker())
+            .thenReturn(EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER))
 
         mvc.perform(
-            get(URL)
+            get(EKSKLUDERT_URL_V1)
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_APOTEKER))
+            .andExpect(content().json(APOTEKER_EKSKLUDERT_RESPONSE_BODY))
     }
 
     @Test
-    fun `'erEkskludertV1' returnerer ekskludert for brukere med loepende ufoeretrygd`() {
-        val ekskluderingStatus = EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.HAR_LOEPENDE_UFOERETRYGD)
-        `when`(service.erEkskludert()).thenReturn(ekskluderingStatus)
+    fun `'erEkskludertV1' skal gi 'ekskludert' for brukere med løpende ufoeretrygd`() {
+        `when`(service.ekskluderingPgaSakEllerApoteker())
+            .thenReturn(EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.HAR_LOEPENDE_UFOERETRYGD))
 
         mvc.perform(
-            get(URL)
+            get(EKSKLUDERT_URL_V1)
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_HAR_LOEPENDE_UFOERETRYGD))
+            .andExpect(content().json(EKSKLUDERT_PGA_UFOERETRYGD_RESPONSE_BODY))
     }
 
     @Test
-    fun `'erEkskludertV2' returnerer ekskludert for medlemmer av apotekerforeningen`() {
-        val ekskluderingStatus = EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER)
-        `when`(service.erEkskludertV2()).thenReturn(ekskluderingStatus)
+    fun `'erEkskludertV2' skal gi 'ekskludert' for medlemmer av apotekerforeningen`() {
+        `when`(service.apotekerEkskludering())
+            .thenReturn(EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER))
 
         mvc.perform(
-            get(URL_V2)
+            get(EKSKLUDERT_URL_V2)
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_APOTEKER))
+            .andExpect(content().json(APOTEKER_EKSKLUDERT_RESPONSE_BODY))
     }
 
     @Test
-    fun `'erEkskludertV2' returnerer ikke ekskludert`() {
-        val ekskluderingStatus = EkskluderingStatus(ekskludert = false, aarsak = EkskluderingAarsak.NONE)
-        `when`(service.erEkskludertV2()).thenReturn(ekskluderingStatus)
+    fun `'erEkskludertV2' skal gi 'ikke ekskludert' hvis ikke ekskludert som apoteker`() {
+        `when`(service.apotekerEkskludering())
+            .thenReturn(EkskluderingStatus(ekskludert = false, aarsak = EkskluderingAarsak.NONE))
 
         mvc.perform(
-            get(URL_V2)
+            get(EKSKLUDERT_URL_V2)
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk())
-            .andExpect(content().json(RESPONSE_BODY_IKKE_EKSKLUDERT))
+            .andExpect(content().json(IKKE_EKSKLUDERT_RESPONSE_BODY))
+    }
+
+    @Test
+    fun `'er-apoteker V1' skal gi 'er apoteker' for medlemmer av apotekerforeningen`() {
+        `when`(service.apotekerEkskludering())
+            .thenReturn(EkskluderingStatus(ekskludert = true, aarsak = EkskluderingAarsak.ER_APOTEKER))
+
+        mvc.perform(
+            get(APOTEKER_URL_V1)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(APOTEKER_RESPONSE_BODY))
+    }
+
+    @Test
+    fun `'er-apoteker V1' skal gi 'ikke apoteker' hvis ikke ekskludert som apoteker`() {
+        `when`(service.apotekerEkskludering())
+            .thenReturn(EkskluderingStatus(ekskludert = false, aarsak = EkskluderingAarsak.NONE))
+
+        mvc.perform(
+            get(APOTEKER_URL_V1)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().json(IKKE_APOTEKER_RESPONSE_BODY))
     }
 
     private companion object {
 
-        private const val URL = "/api/v1/ekskludert"
-        private const val URL_V2 = "/api/v2/ekskludert"
+        private const val EKSKLUDERT_URL_V1 = "/api/v1/ekskludert"
+        private const val EKSKLUDERT_URL_V2 = "/api/v2/ekskludert"
+        private const val APOTEKER_URL_V1 = "/api/v1/er-apoteker"
 
         @Language("json")
-        private const val RESPONSE_BODY_APOTEKER = """{
+        private const val APOTEKER_RESPONSE_BODY = """{
+	"apoteker": true,
+	"aarsak": "ER_APOTEKER"
+}"""
+
+        @Language("json")
+        private const val IKKE_APOTEKER_RESPONSE_BODY = """{
+	"apoteker": false,
+	"aarsak": "NONE"
+}"""
+
+        @Language("json")
+        private const val APOTEKER_EKSKLUDERT_RESPONSE_BODY = """{
 	"ekskludert": true,
 	"aarsak": "ER_APOTEKER"
 }"""
+
         @Language("json")
-        private const val RESPONSE_BODY_HAR_LOEPENDE_UFOERETRYGD = """{
+        private const val EKSKLUDERT_PGA_UFOERETRYGD_RESPONSE_BODY = """{
 	"ekskludert": true,
 	"aarsak": "HAR_LOEPENDE_UFOERETRYGD"
 }"""
 
         @Language("json")
-        private const val RESPONSE_BODY_IKKE_EKSKLUDERT = """{
+        private const val IKKE_EKSKLUDERT_RESPONSE_BODY = """{
 	"ekskludert": false,
 	"aarsak": "NONE"
 }"""

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/map/EkskluderingMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ekskludering/api/map/EkskluderingMapperTest.kt
@@ -1,42 +1,49 @@
 package no.nav.pensjon.kalkulator.ekskludering.api.map
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import no.nav.pensjon.kalkulator.ekskludering.EkskluderingAarsak
 import no.nav.pensjon.kalkulator.ekskludering.EkskluderingStatus
-import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingAarsakV1
-import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingAarsakV2
-import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingStatusV1
-import no.nav.pensjon.kalkulator.ekskludering.api.dto.EkskluderingStatusV2
-import org.junit.jupiter.api.Test
+import no.nav.pensjon.kalkulator.ekskludering.api.dto.*
 
-class EkskluderingMapperTest {
+class EkskluderingMapperTest : FunSpec({
 
-    @Test
-    fun `'version1' maps to data transfer object version 1`() {
+    test("'statusV1' should map to data transfer object version 1") {
         val source = EkskluderingStatus(
             ekskludert = true,
             aarsak = EkskluderingAarsak.HAR_GJENLEVENDEYTELSE
         )
-        val expected = EkskluderingStatusV1(
-            ekskludert = true,
-            aarsak = EkskluderingAarsakV1.HAR_GJENLEVENDEYTELSE
-        )
 
-        EkskluderingMapper.version1(source) shouldBe expected
+        EkskluderingMapper.statusV1(source) shouldBe
+                EkskluderingStatusV1(
+                    ekskludert = true,
+                    aarsak = EkskluderingAarsakV1.HAR_GJENLEVENDEYTELSE
+                )
     }
 
-    @Test
-    fun `'version2' maps to data transfer object version 2`() {
+    test("'statusV2' should map to data transfer object version 2") {
         val source = EkskluderingStatus(
             ekskludert = true,
             aarsak = EkskluderingAarsak.ER_APOTEKER
         )
-        val expected = EkskluderingStatusV2(
-            ekskludert = true,
-            aarsak = EkskluderingAarsakV2.ER_APOTEKER
-        )
 
-        EkskluderingMapper.version2(source) shouldBe expected
+        EkskluderingMapper.statusV2(source) shouldBe
+                EkskluderingStatusV2(
+                    ekskludert = true,
+                    aarsak = EkskluderingAarsakV2.ER_APOTEKER
+                )
     }
 
-}
+    test("'apotekerStatusV1' should map to data transfer object version 1") {
+        val source = EkskluderingStatus(
+            ekskludert = true,
+            aarsak = EkskluderingAarsak.ER_APOTEKER
+        )
+
+        EkskluderingMapper.apotekerStatusV1(source) shouldBe
+                ApotekerStatusV1(
+                    apoteker = true,
+                    aarsak = EkskluderingAarsakV2.ER_APOTEKER
+                )
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/tp/TpTjenestepensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tjenestepensjon/client/tp/TpTjenestepensjonClientTest.kt
@@ -74,6 +74,14 @@ class TpTjenestepensjonClientTest : FunSpec({
         }
     }
 
+    test("'erApoteker' gir 'false' når personen ikke finnes i TP-registeret") {
+        server?.arrangeResponse(HttpStatus.NOT_FOUND, PERSON_IKKE_FUNNET_RESPONSE_BODY)
+
+        Arrange.webClientContextRunner().run {
+            client(context = it).erApoteker(pid) shouldBe false
+        }
+    }
+
     test("'tjenestepensjon' gir forhold-liste når personen har tjenestepensjonsforhold") {
         server?.arrangeOkJsonResponse(TJENESTEPENSJON)
 
@@ -150,6 +158,16 @@ class TpTjenestepensjonClientTest : FunSpec({
         }
     }
 })
+
+@Language("json")
+private const val PERSON_IKKE_FUNNET_RESPONSE_BODY =
+    """{
+    "type": "about:blank",
+    "title": "Not Found",
+    "status": 404,
+    "detail": "Person ikke funnet.",
+    "instance": "/api/tjenestepensjon/medlem/afp/apotekerforeningen/ersisteforhold"
+}"""
 
 object TpTjenestepensjonClientTestObjects {
 


### PR DESCRIPTION
TP-kallet `apotekerforeningen/ersisteforhold` gir noen ganger `404`– 'person ikke funnet'.
Det gjør at API-kallene for ekskludering feiler, og det logges av backend på nivå `Error`.
Siden vi ikke kan unngå 'person ikke funnet', bør dette ikke føre til feil og isteden logges som `Warning`.
Denne PR gjør at 'person ikke funnet' gir svar `ersisteforhold`= `false`, og logger det som `Warning`.

I tillegg:

- Legger til tester for `er-apoteker`-endpunktet
- Konverterer tester til Kotest og Mockk
- Fjerner bruk av versjonsnumre i domenelaget (i `EkskluderingFacade`) – versjonering bør begrenses til API-laget