### PR TITLE
TPP-260 Add endpoint for 'ansatts enheter'

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -104,6 +104,8 @@ spec:
       rules:
         - application: etterlatte-api
           namespace: etterlatte
+        - application: navansatt
+          namespace: pensjon-saksbehandling
         - application: pdl-api
           namespace: pdl
           cluster: dev-fss
@@ -149,6 +151,10 @@ spec:
       value: dev-fss:pensjonselvbetjening:pensjon-selvbetjening-fss-gateway
     - name: FSS_GATEWAY_URL
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
+    - name: NAV_ANSATT_SERVICE_ID
+      value: dev-gcp:pensjon-saksbehandling:navansatt
+    - name: NAV_ANSATT_URL
+      value: http://navansatt.pensjon-saksbehandling
     - name: NORSK_PENSJON_URL
       value: https://pensjon-selvbetjening-fss-gateway.dev-fss-pub.nais.io
     - name: NORSK_PENSJON_MOCK_URL

--- a/.nais/deploy-prod.yml
+++ b/.nais/deploy-prod.yml
@@ -71,6 +71,8 @@ spec:
       rules:
         - application: etterlatte-api
           namespace: etterlatte
+        - application: navansatt
+          namespace: pensjon-saksbehandling
         - application: pdl-api
           namespace: pdl
           cluster: prod-fss
@@ -122,6 +124,10 @@ spec:
       value: prod-fss:pensjonselvbetjening:pensjon-selvbetjening-fss-gateway
     - name: FSS_GATEWAY_URL
       value: https://pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
+    - name: NAV_ANSATT_SERVICE_ID
+      value: prod-gcp:pensjon-saksbehandling:navansatt
+    - name: NAV_ANSATT_URL
+      value: http://navansatt.pensjon-saksbehandling
     - name: NORSK_PENSJON_URL
       value: https://pensjon-selvbetjening-fss-gateway.prod-fss-pub.nais.io
     - name: OMSTILLINGSSTOENAD_SERVICE_ID

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetService.kt
@@ -1,0 +1,14 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet
+
+import no.nav.pensjon.kalkulator.ansatt.enhet.client.EnhetClient
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.SecurityContextNavIdExtractor
+import org.springframework.stereotype.Service
+
+@Service
+class EnhetService(
+    private val client: EnhetClient,
+    private val ansattIdGetter: SecurityContextNavIdExtractor
+) {
+    fun tjenestekontorEnhetListe(): AnsattEnhetResult =
+        client.fetchTjenestekontorEnhetListe(ansattId = ansattIdGetter.id())
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetService.kt
@@ -4,11 +4,15 @@ import no.nav.pensjon.kalkulator.ansatt.enhet.client.EnhetClient
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.SecurityContextNavIdExtractor
 import org.springframework.stereotype.Service
 
+/**
+ * Tjeneste for å hente hvilke enheter den innloggede Nav-ansatte er tilknyttet.
+ * "Enhet" betyr i denne sammenheng tjenestekontor, og enhets-ID er det samme som tjenestekontornummer (TKNR).
+ */
 @Service
 class EnhetService(
     private val client: EnhetClient,
     private val ansattIdGetter: SecurityContextNavIdExtractor
 ) {
-    fun tjenestekontorEnhetListe(): AnsattEnhetResult =
+    fun tjenestekontorEnhetListe(): TjenestekontorEnheter =
         client.fetchTjenestekontorEnhetListe(ansattId = ansattIdGetter.id())
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/TjenestekontorEnhet.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/TjenestekontorEnhet.kt
@@ -1,0 +1,13 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet
+
+import no.nav.pensjon.kalkulator.validity.Problem
+
+data class AnsattEnhetResult(
+    val enhetListe: List<TjenestekontorEnhet>,
+    val problem: Problem? = null
+)
+data class TjenestekontorEnhet(
+    val id: String,
+    val navn: String,
+    val nivaa: String
+)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/TjenestekontorEnheter.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/TjenestekontorEnheter.kt
@@ -2,10 +2,11 @@ package no.nav.pensjon.kalkulator.ansatt.enhet
 
 import no.nav.pensjon.kalkulator.validity.Problem
 
-data class AnsattEnhetResult(
+data class TjenestekontorEnheter(
     val enhetListe: List<TjenestekontorEnhet>,
     val problem: Problem? = null
 )
+
 data class TjenestekontorEnhet(
     val id: String,
     val navn: String,

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/AnsattEnhetV1Controller.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/AnsattEnhetV1Controller.kt
@@ -1,0 +1,89 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import mu.KotlinLogging
+import no.nav.pensjon.kalkulator.ansatt.enhet.EnhetService
+import no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl.AnsattEnhetV1Problem
+import no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl.AnsattEnhetV1ProblemType
+import no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl.AnsattEnhetV1Result
+import no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl.ResultMapper.toDto
+import no.nav.pensjon.kalkulator.common.api.ControllerBase
+import no.nav.pensjon.kalkulator.tech.trace.TraceAid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/intern")
+class AnsattEnhetV1Controller(
+    private val service: EnhetService,
+    private val traceAid: TraceAid
+) : ControllerBase(traceAid) {
+
+    private val log = KotlinLogging.logger {}
+
+    @GetMapping("v1/enheter")
+    @Operation(
+        summary = "Hent den ansattes enheter",
+        description = "Henter en liste over den innloggede ansattes enheter, dvs. tjenestekontornummer."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Henting av enheter utført."
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "Henting av enheter kunne ikke utføres pga. manglende/feilaktig autentisering."
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Henting av enheter kunne ikke utføres pga. manglende tilgang til tjenesten eller personen."
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Henting av enheter kunne ikke utføres fordi angitt ansatt-ID ikke finnes i systemet."
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "Henting av enheter kunne ikke utføres pga. feil i systemet."
+            )
+        ]
+    )
+    fun tjenestekontorEnhetListe(): ResponseEntity<AnsattEnhetV1Result> =
+        try {
+            traceAid.begin()
+            val result = toDto(service.tjenestekontorEnhetListe())
+            ResponseEntity.status(result.problem?.kode?.httpStatus ?: HttpStatus.OK).body(result)
+        } catch (e: Exception) {
+            log.error(e) { "Intern feil" }
+            throw e
+        } finally {
+            traceAid.end()
+        }
+
+    override fun errorMessage() = ERROR_MESSAGE
+
+    @ExceptionHandler(value = [Exception::class])
+    private fun internalError(e: Exception): ResponseEntity<AnsattEnhetV1Result> =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem(e))
+
+    private companion object {
+        private const val ERROR_MESSAGE = "feil ved henting av ansattes enheter"
+
+        private fun problem(e: Exception) =
+            AnsattEnhetV1Result(
+                enhetListe = emptyList(),
+                problem = AnsattEnhetV1Problem(
+                    kode = AnsattEnhetV1ProblemType.SERVERFEIL,
+                    beskrivelse = e.message ?: e.javaClass.simpleName
+                )
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/AnsattEnhetV1Tjenestekontor.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/AnsattEnhetV1Tjenestekontor.kt
@@ -16,7 +16,7 @@ data class AnsattEnhetV1Result(
     @field:NotNull
     val enhetListe: List<AnsattEnhetV1Tjenestekontor>,
 
-    @field:Schema(description = "Eventelt problem som oppstod ved henting av enheter")
+    @field:Schema(description = "Eventuelt problem som oppstod ved henting av enheter")
     val problem: AnsattEnhetV1Problem?
 )
 

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/AnsattEnhetV1Tjenestekontor.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/AnsattEnhetV1Tjenestekontor.kt
@@ -1,0 +1,40 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import no.nav.pensjon.kalkulator.validity.ProblemType
+import org.springframework.http.HttpStatus
+
+/**
+ * Data transfer object (DTO) for resultatet av henting av tjenestekontor-enheter for en ansatt.
+ */
+@JsonInclude(NON_NULL)
+data class AnsattEnhetV1Result(
+    @field:Schema(description = "Liste over enheter (tjenestekontor)")
+    @field:NotNull
+    val enhetListe: List<AnsattEnhetV1Tjenestekontor>,
+
+    @field:Schema(description = "Eventelt problem som oppstod ved henting av enheter")
+    val problem: AnsattEnhetV1Problem?
+)
+
+data class AnsattEnhetV1Tjenestekontor(
+    @field:NotNull val id: String,
+    @field:NotNull val navn: String
+)
+
+data class AnsattEnhetV1Problem(
+    @field:NotNull val kode: AnsattEnhetV1ProblemType,
+    @field:NotNull val beskrivelse: String
+)
+
+enum class AnsattEnhetV1ProblemType(
+    val internalValue: ProblemType,
+    val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+) {
+    ANSATT_IKKE_FUNNET(internalValue = ProblemType.PERSON_IKKE_FUNNET, httpStatus = HttpStatus.NOT_FOUND),
+    ANNEN_KLIENTFEIL(internalValue = ProblemType.ANNEN_KLIENTFEIL),
+    SERVERFEIL(internalValue = ProblemType.SERVERFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapper.kt
@@ -1,12 +1,12 @@
 package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl
 
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
 import no.nav.pensjon.kalkulator.validity.Problem
 
 object ResultMapper {
 
-    fun toDto(source: AnsattEnhetResult) =
+    fun toDto(source: TjenestekontorEnheter) =
         AnsattEnhetV1Result(
             enhetListe = source.enhetListe.map(::tjenestekontor),
             problem = source.problem?.let(::problem)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapper.kt
@@ -1,0 +1,27 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl
+
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
+import no.nav.pensjon.kalkulator.validity.Problem
+
+object ResultMapper {
+
+    fun toDto(source: AnsattEnhetResult) =
+        AnsattEnhetV1Result(
+            enhetListe = source.enhetListe.map(::tjenestekontor),
+            problem = source.problem?.let(::problem)
+        )
+
+    private fun tjenestekontor(source: TjenestekontorEnhet) =
+        AnsattEnhetV1Tjenestekontor(
+            id = source.id,
+            navn = source.navn
+        )
+
+    private fun problem(source: Problem) =
+        AnsattEnhetV1Problem(
+            kode = AnsattEnhetV1ProblemType.entries.firstOrNull { it.internalValue == source.type }
+                ?: AnsattEnhetV1ProblemType.SERVERFEIL,
+            beskrivelse = source.beskrivelse
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/EnhetClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/EnhetClient.kt
@@ -1,0 +1,7 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.client
+
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+
+interface EnhetClient {
+    fun fetchTjenestekontorEnhetListe(ansattId: String): AnsattEnhetResult
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/EnhetClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/EnhetClient.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.kalkulator.ansatt.enhet.client
 
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 
 interface EnhetClient {
-    fun fetchTjenestekontorEnhetListe(ansattId: String): AnsattEnhetResult
+    fun fetchTjenestekontorEnhetListe(ansattId: String): TjenestekontorEnheter
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClient.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt
 
 import com.github.benmanes.caffeine.cache.Cache
 import mu.KotlinLogging
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 import no.nav.pensjon.kalkulator.ansatt.enhet.client.EnhetClient
 import no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl.NavEnhetProblemDto
 import no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl.NavEnhetResultDto
@@ -40,15 +40,15 @@ class NavAnsattClient(
     private val log = KotlinLogging.logger {}
     private val webClient = webClientBuilder.baseUrl(baseUrl).build()
 
-    private val cache: Cache<String, AnsattEnhetResult> =
-        createCache("enhet", cacheManager)
+    private val cache: Cache<String, TjenestekontorEnheter> =
+        createCache("ansattenheter", cacheManager)
 
-    override fun fetchTjenestekontorEnhetListe(ansattId: String): AnsattEnhetResult =
+    override fun fetchTjenestekontorEnhetListe(ansattId: String): TjenestekontorEnheter =
         cache.getIfPresent(ansattId) ?: fetchFreshData(ansattId).also { cache.put(ansattId, it) }
 
     override fun service() = service
 
-    private fun fetchFreshData(ansattId: String): AnsattEnhetResult {
+    private fun fetchFreshData(ansattId: String): TjenestekontorEnheter {
         val uri = "$BASE_PATH/$ansattId/enheter"
 
         return try {
@@ -62,7 +62,7 @@ class NavAnsattClient(
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?.let(::fromDto)
-                ?: AnsattEnhetResult(enhetListe = emptyList())
+                ?: TjenestekontorEnheter(enhetListe = emptyList())
         } catch (e: WebClientRequestException) {
             throw EgressException("Failed calling $uri", e)
         } catch (e: WebClientResponseException) {
@@ -79,12 +79,19 @@ class NavAnsattClient(
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 
-    private fun handle(egressException: EgressException): AnsattEnhetResult =
+    /**
+     * Ved klientfeil (4xx) der responsen inneholder en NavEnhetProblemDto (problembeskrivelse),
+     * så returneres et TjenestekontorEnheter-objekt med problembeskrivelsen.
+     * I øvrige tilfeller kastes bare EgressException videre.
+     */
+    private fun handle(egressException: EgressException): TjenestekontorEnheter =
         try {
+            if (egressException.isClientError.not()) throw egressException
+
             jsonMapper.readValue(
                 egressException.message,
                 NavEnhetProblemDto::class.java
-            )?.let(::fromDto) ?: throw egressException
+            )?.let { fromDto(dto = it, httpStatus = egressException.statusCode) } ?: throw egressException
         } catch (jacksonException: JacksonException) {
             log.warn(jacksonException) {
                 redact(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClient.kt
@@ -1,0 +1,104 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt
+
+import com.github.benmanes.caffeine.cache.Cache
+import mu.KotlinLogging
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.client.EnhetClient
+import no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl.NavEnhetProblemDto
+import no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl.NavEnhetResultDto
+import no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl.NavEnhetResultMapper.fromDto
+import no.nav.pensjon.kalkulator.common.client.ExternalServiceClient
+import no.nav.pensjon.kalkulator.person.FoedselsnummerUtil.redact
+import no.nav.pensjon.kalkulator.tech.cache.CacheConfigurator.createCache
+import no.nav.pensjon.kalkulator.tech.security.egress.EgressAccess
+import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressService
+import no.nav.pensjon.kalkulator.tech.trace.TraceAid
+import no.nav.pensjon.kalkulator.tech.web.CustomHttpHeaders
+import no.nav.pensjon.kalkulator.tech.web.EgressException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.json.JsonMapper
+
+@Component
+class NavAnsattClient(
+    @Value($$"${nav-ansatt.url}") baseUrl: String,
+    @Value($$"${web-client.retry-attempts}") retryAttempts: String,
+    webClientBuilder: WebClient.Builder,
+    cacheManager: CaffeineCacheManager,
+    private val jsonMapper: JsonMapper,
+    private val traceAid: TraceAid,
+) : ExternalServiceClient(retryAttempts), EnhetClient {
+
+    private val log = KotlinLogging.logger {}
+    private val webClient = webClientBuilder.baseUrl(baseUrl).build()
+
+    private val cache: Cache<String, AnsattEnhetResult> =
+        createCache("enhet", cacheManager)
+
+    override fun fetchTjenestekontorEnhetListe(ansattId: String): AnsattEnhetResult =
+        cache.getIfPresent(ansattId) ?: fetchFreshData(ansattId).also { cache.put(ansattId, it) }
+
+    override fun service() = service
+
+    private fun fetchFreshData(ansattId: String): AnsattEnhetResult {
+        val uri = "$BASE_PATH/$ansattId/enheter"
+
+        return try {
+            webClient
+                .get()
+                .uri(uri)
+                .accept(MediaType.APPLICATION_JSON)
+                .headers(::setHeaders)
+                .retrieve()
+                .bodyToMono(object : ParameterizedTypeReference<List<NavEnhetResultDto>>() {})
+                .retryWhen(retryBackoffSpec(uri))
+                .block()
+                ?.let(::fromDto)
+                ?: AnsattEnhetResult(enhetListe = emptyList())
+        } catch (e: WebClientRequestException) {
+            throw EgressException("Failed calling $uri", e)
+        } catch (e: WebClientResponseException) {
+            throw EgressException(e.responseBodyAsString, e)
+        } catch (e: EgressException) {
+            handle(e)
+        }
+    }
+
+    override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
+
+    private fun setHeaders(headers: HttpHeaders) {
+        headers.setBearerAuth(EgressAccess.token(service).value)
+        headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
+    }
+
+    private fun handle(egressException: EgressException): AnsattEnhetResult =
+        try {
+            jsonMapper.readValue(
+                egressException.message,
+                NavEnhetProblemDto::class.java
+            )?.let(::fromDto) ?: throw egressException
+        } catch (jacksonException: JacksonException) {
+            log.warn(jacksonException) {
+                redact(
+                    "Failed to handle response from ${service.description}" +
+                            " - ${jacksonException.message}" +
+                            " - attempted to deserialize '${egressException.message}' as NavEnhetProblemDto"
+                )
+            }
+            throw egressException
+        }
+
+    private companion object {
+        private const val BASE_PATH = "/navansatt"
+
+        private val service = EgressService.NAV_ANSATT
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultDto.kt
@@ -1,0 +1,16 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl
+
+/**
+ * Data transfer object (DTO) for a tjenestekontor-enhet.
+ * The fields are specified by NAVEnhetResult in navansatt, ref.
+ * github.com/navikt/navansatt/blob/main/src/main/kotlin/no/nav/navansatt/Routes.kt
+ */
+data class NavEnhetResultDto(
+    val id: String,
+    val navn: String,
+    val nivaa: String
+)
+
+data class NavEnhetProblemDto(
+    val message: String
+)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultMapper.kt
@@ -1,0 +1,27 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl
+
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
+import no.nav.pensjon.kalkulator.validity.Problem
+import no.nav.pensjon.kalkulator.validity.ProblemType
+
+object NavEnhetResultMapper {
+
+    fun fromDto(dto: List<NavEnhetResultDto>) =
+        AnsattEnhetResult(
+            enhetListe = dto.map(::enhet)
+        )
+
+    fun fromDto(dto: NavEnhetProblemDto) =
+        AnsattEnhetResult(
+            enhetListe = emptyList(),
+            problem = Problem(type = ProblemType.PERSON_IKKE_FUNNET, beskrivelse = dto.message)
+        )
+
+    private fun enhet(dto: NavEnhetResultDto) =
+        TjenestekontorEnhet(
+            id = dto.id,
+            navn = dto.navn,
+            nivaa = dto.nivaa
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultMapper.kt
@@ -1,21 +1,26 @@
 package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl
 
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
 import no.nav.pensjon.kalkulator.validity.Problem
 import no.nav.pensjon.kalkulator.validity.ProblemType
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 
 object NavEnhetResultMapper {
 
     fun fromDto(dto: List<NavEnhetResultDto>) =
-        AnsattEnhetResult(
+        TjenestekontorEnheter(
             enhetListe = dto.map(::enhet)
         )
 
-    fun fromDto(dto: NavEnhetProblemDto) =
-        AnsattEnhetResult(
+    fun fromDto(dto: NavEnhetProblemDto, httpStatus: HttpStatusCode?) =
+        TjenestekontorEnheter(
             enhetListe = emptyList(),
-            problem = Problem(type = ProblemType.PERSON_IKKE_FUNNET, beskrivelse = dto.message)
+            problem = Problem(
+                type = httpStatus?.let(::problemType) ?: ProblemType.SERVERFEIL,
+                beskrivelse = dto.message
+            )
         )
 
     private fun enhet(dto: NavEnhetResultDto) =
@@ -24,4 +29,10 @@ object NavEnhetResultMapper {
             navn = dto.navn,
             nivaa = dto.nivaa
         )
+
+    private fun problemType(httpStatus: HttpStatusCode): ProblemType =
+        if (httpStatus == HttpStatus.NOT_FOUND)
+            ProblemType.PERSON_IKKE_FUNNET
+        else
+            ProblemType.ANNEN_KLIENTFEIL
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/v1/acl/result/SimuleringResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/simulering/api/v1/acl/result/SimuleringResult.kt
@@ -35,7 +35,7 @@ data class SimuleringV1Result(
     @field:Schema(description = "Pensjonsgivende inntekter for hvert år")
     val pensjonsgivendeInntektListe: List<SimuleringV1AarligBeloep>?,
 
-    @field:Schema(description = "Eventelt problem som oppstod under simuleringen")
+    @field:Schema(description = "Eventuelt problem som oppstod under simuleringen")
     val problem: SimuleringV1Problem?
 )
 

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/api/OpenApiConfiguration.kt
@@ -48,6 +48,7 @@ class OpenApiConfiguration {
         return GroupedOpenApi.builder()
             .group("current")
             .pathsToMatch(
+                "/api/intern/v1/enheter",
                 "/api/intern/v1/eps",
                 "/api/intern/v1/lagre-simulering",
                 "/api/intern/v1/pensjon/simulering",

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/config/EgressService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/config/EgressService.kt
@@ -16,6 +16,7 @@ enum class EgressService(
     GANDALF_STS("Gandalf Security Token Service", "STS", "Tokenveksling til SAML", GatewayUsage.INTERNAL),
     ID_PORTEN("ID-porten", "IDP", "Token-utsteder"),
     MICROSOFT_ENTRA_ID("Microsoft Entra ID", "MEID", "OAuth2 configuration data"),
+    NAV_ANSATT("Nav-ansatt", "NA", "Info om Nav-ansatt"),
     NORSK_PENSJON("Norsk Pensjon", "NP", "Private pensjonsavtaler", GatewayUsage.INTERNAL),
     OAUTH2_TOKEN("OAuth2 token", "OA2", "OAuth2 access token"),
     PENSJON_PERSONDATA(

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/config/EgressServiceSecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/config/EgressServiceSecurityConfiguration.kt
@@ -14,6 +14,7 @@ class EgressServiceSecurityConfiguration {
 
     @Bean
     fun egressServiceListsByAudience(
+        @Value("\${nav-ansatt.service-id}") navAnsattServiceId: String,
         @Value("\${pen.service-id}") pensjonsfagligKjerneServiceId: String,
         @Value("\${popp.service-id}") pensjonsopptjeningServiceId: String,
         @Value("\${pensjon-persondata.service-id}") pensjonPersondataServiceId: String,
@@ -38,6 +39,7 @@ class EgressServiceSecurityConfiguration {
     ) =
         EgressServiceListsByAudience(
             mapOf(
+                navAnsattServiceId to listOf(EgressService.NAV_ANSATT),
                 pensjonsfagligKjerneServiceId to listOf(EgressService.PENSJONSFAGLIG_KJERNE),
                 pensjonsopptjeningServiceId to listOf(EgressService.PENSJONSOPPTJENING),
                 pensjonPersondataServiceId to listOf(EgressService.PENSJON_PERSONDATA),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,8 @@ management.endpoints.web.exposure.exclude=beans,env,heapdump
 proxy.service-id=${FSS_GATEWAY_SERVICE_ID:dev-fss:pensjonselvbetjening:pensjon-selvbetjening-fss-gateway}
 proxy.url=${FSS_GATEWAY_URL:https://pensjon-selvbetjening-fss-gateway.intern.dev.nav.no}
 
+nav-ansatt.service-id=${NAV_ANSATT_SERVICE_ID:dev-gcp:pensjon-saksbehandling:navansatt}
+nav-ansatt.url=${NAV_ANSATT_URL:https://navansatt.intern.dev.nav.no}
 norsk-pensjon.url=${proxy.url}
 omstillingsstoenad.service-id=${OMSTILLINGSSTOENAD_SERVICE_ID:dev-gcp:etterlatte:etterlatte-api}
 omstillingsstoenad.url=${OMSTILLINGSSTOENAD_URL:https://etterlatte-api.intern.dev.nav.no}

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetServiceTest.kt
@@ -30,7 +30,7 @@ class EnhetServiceTest : ShouldSpec({
                 TjenestekontorEnhet("enhet1", "Tjenestekontor 1", nivaa = "02"),
                 TjenestekontorEnhet("enhet2", "Tjenestekontor 2", nivaa = "03"),
             )
-            every { client.fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) } returns AnsattEnhetResult(enhetListe = expectedEnhetList)
+            every { client.fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) } returns TjenestekontorEnheter(enhetListe = expectedEnhetList)
 
             service.tjenestekontorEnhetListe().enhetListe shouldBe expectedEnhetList
 
@@ -40,7 +40,7 @@ class EnhetServiceTest : ShouldSpec({
 
     context("failure - client returns no data") {
         should("return an empty list and no problem description") {
-            val expectedResult = AnsattEnhetResult(
+            val expectedResult = TjenestekontorEnheter(
                 enhetListe = emptyList(),
                 problem = null
             )
@@ -54,7 +54,7 @@ class EnhetServiceTest : ShouldSpec({
 
     context("failure - ansatt not found") {
         should("return an empty list and a problem description") {
-            val expectedResult = AnsattEnhetResult(
+            val expectedResult = TjenestekontorEnheter(
                 enhetListe = emptyList(),
                 problem = Problem(
                     type = ProblemType.PERSON_IKKE_FUNNET,

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/EnhetServiceTest.kt
@@ -1,0 +1,73 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.pensjon.kalkulator.ansatt.enhet.client.EnhetClient
+import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.audit.SecurityContextNavIdExtractor
+import no.nav.pensjon.kalkulator.validity.Problem
+import no.nav.pensjon.kalkulator.validity.ProblemType
+
+class EnhetServiceTest : ShouldSpec({
+
+    val ansattIdGetter = mockk<SecurityContextNavIdExtractor>().apply {
+        every { id() } returns ANSATT_ID
+    }
+
+    val client: EnhetClient = mockk()
+    val service = EnhetService(client, ansattIdGetter)
+
+    fun verifyCalls() {
+        verify { client.fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) }
+        verify { ansattIdGetter.id() }
+    }
+
+    context("success - client returns data") {
+        should("return a list of TjenestekontorEnhet") {
+            val expectedEnhetList = listOf(
+                TjenestekontorEnhet("enhet1", "Tjenestekontor 1", nivaa = "02"),
+                TjenestekontorEnhet("enhet2", "Tjenestekontor 2", nivaa = "03"),
+            )
+            every { client.fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) } returns AnsattEnhetResult(enhetListe = expectedEnhetList)
+
+            service.tjenestekontorEnhetListe().enhetListe shouldBe expectedEnhetList
+
+            verifyCalls()
+        }
+    }
+
+    context("failure - client returns no data") {
+        should("return an empty list and no problem description") {
+            val expectedResult = AnsattEnhetResult(
+                enhetListe = emptyList(),
+                problem = null
+            )
+            every { client.fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) } returns expectedResult
+
+            service.tjenestekontorEnhetListe() shouldBe expectedResult
+
+            verifyCalls()
+        }
+    }
+
+    context("failure - ansatt not found") {
+        should("return an empty list and a problem description") {
+            val expectedResult = AnsattEnhetResult(
+                enhetListe = emptyList(),
+                problem = Problem(
+                    type = ProblemType.PERSON_IKKE_FUNNET,
+                    beskrivelse = "User with ID $ANSATT_ID not found"
+                )
+            )
+            every { client.fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) } returns expectedResult
+
+            service.tjenestekontorEnhetListe() shouldBe expectedResult
+
+            verifyCalls()
+        }
+    }
+})
+
+private const val ANSATT_ID = "X123456"

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/AnsattEnhetV1ControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/AnsattEnhetV1ControllerTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.verify
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 import no.nav.pensjon.kalkulator.ansatt.enhet.EnhetService
 import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
@@ -41,7 +41,7 @@ class AnsattEnhetV1ControllerTest : ShouldSpec() {
 
         context("success - service responds") {
             should("return status '200 OK' with a list of enheter") {
-                every { enhetService.tjenestekontorEnhetListe() } returns AnsattEnhetResult(
+                every { enhetService.tjenestekontorEnhetListe() } returns TjenestekontorEnheter(
                     enhetListe = listOf(
                         TjenestekontorEnhet(id = "123", navn = "Oslo", nivaa = "1"),
                         TjenestekontorEnhet(id = "456", navn = "Bergen", nivaa = "2")
@@ -61,7 +61,7 @@ class AnsattEnhetV1ControllerTest : ShouldSpec() {
 
         context("failure - ansatt not found") {
             should(" return status '404 Not Found' with problem description as content") {
-                every { enhetService.tjenestekontorEnhetListe() } returns AnsattEnhetResult(
+                every { enhetService.tjenestekontorEnhetListe() } returns TjenestekontorEnheter(
                     enhetListe = emptyList(),
                     problem = Problem(
                         type = ProblemType.PERSON_IKKE_FUNNET,
@@ -97,7 +97,7 @@ class AnsattEnhetV1ControllerTest : ShouldSpec() {
 
         context("failure - empty response") {
             should("return status '200 OK' with empty list as content") {
-                every { enhetService.tjenestekontorEnhetListe() } returns AnsattEnhetResult(enhetListe = emptyList())
+                every { enhetService.tjenestekontorEnhetListe() } returns TjenestekontorEnheter(enhetListe = emptyList())
                 arrangeTrace()
 
                 mockMvc.get(URL)

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/AnsattEnhetV1ControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/AnsattEnhetV1ControllerTest.kt
@@ -1,0 +1,114 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.verify
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.EnhetService
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
+import no.nav.pensjon.kalkulator.tech.trace.TraceAid
+import no.nav.pensjon.kalkulator.validity.Problem
+import no.nav.pensjon.kalkulator.validity.ProblemType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(AnsattEnhetV1Controller::class)
+class AnsattEnhetV1ControllerTest : ShouldSpec() {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var enhetService: EnhetService
+
+    @MockkBean
+    private lateinit var traceAid: TraceAid
+
+    init {
+        fun arrangeTrace() {
+            every { traceAid.begin() } returns Unit
+            every { traceAid.end() } returns Unit
+        }
+
+        fun verifyTrace() {
+            verify { traceAid.begin() }
+            verify { traceAid.end() }
+        }
+
+        context("success - service responds") {
+            should("return status '200 OK' with a list of enheter") {
+                every { enhetService.tjenestekontorEnhetListe() } returns AnsattEnhetResult(
+                    enhetListe = listOf(
+                        TjenestekontorEnhet(id = "123", navn = "Oslo", nivaa = "1"),
+                        TjenestekontorEnhet(id = "456", navn = "Bergen", nivaa = "2")
+                    )
+                )
+                arrangeTrace()
+
+                mockMvc.get(URL)
+                    .andExpect { status { isOk() } }
+                    .andReturn()
+                    .response.contentAsString shouldBe
+                        """{"enhetListe":[{"id":"123","navn":"Oslo"},{"id":"456","navn":"Bergen"}]}"""
+
+                verifyTrace()
+            }
+        }
+
+        context("failure - ansatt not found") {
+            should(" return status '404 Not Found' with problem description as content") {
+                every { enhetService.tjenestekontorEnhetListe() } returns AnsattEnhetResult(
+                    enhetListe = emptyList(),
+                    problem = Problem(
+                        type = ProblemType.PERSON_IKKE_FUNNET,
+                        beskrivelse = "User with ID X123456 not found"
+                    )
+                )
+                arrangeTrace()
+
+                mockMvc.get(URL)
+                    .andExpect { status { isNotFound() } }
+                    .andReturn()
+                    .response.contentAsString shouldBe
+                        """{"enhetListe":[],"problem":{"kode":"ANSATT_IKKE_FUNNET","beskrivelse":"User with ID X123456 not found"}}"""
+
+                verifyTrace()
+            }
+        }
+
+        context("failure - exception occurs") {
+            should(" return status '500 Internal Server Error' with exception message as content") {
+                every { enhetService.tjenestekontorEnhetListe() } throws RuntimeException("Internal error")
+                arrangeTrace()
+
+                mockMvc.get(URL)
+                    .andExpect { status { isInternalServerError() } }
+                    .andReturn()
+                    .response.contentAsString shouldBe
+                        """{"enhetListe":[],"problem":{"kode":"SERVERFEIL","beskrivelse":"Internal error"}}"""
+
+                verifyTrace()
+            }
+        }
+
+        context("failure - empty response") {
+            should("return status '200 OK' with empty list as content") {
+                every { enhetService.tjenestekontorEnhetListe() } returns AnsattEnhetResult(enhetListe = emptyList())
+                arrangeTrace()
+
+                mockMvc.get(URL)
+                    .andExpect { status { isOk() } }
+                    .andReturn()
+                    .response.contentAsString shouldBe """{"enhetListe":[]}"""
+
+                verifyTrace()
+            }
+        }
+    }
+}
+
+private const val URL = "/api/intern/v1/enheter"

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapperTest.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
 import no.nav.pensjon.kalkulator.validity.Problem
 import no.nav.pensjon.kalkulator.validity.ProblemType
@@ -12,7 +12,7 @@ class ResultMapperTest : ShouldSpec({
     context("success - single element") {
         should("map to a single-element AnsattEnhetV1Tjenestekontor list") {
             ResultMapper.toDto(
-                source = AnsattEnhetResult(
+                source = TjenestekontorEnheter(
                     enhetListe = listOf(TjenestekontorEnhet(id = "1001", navn = "Kontor A", nivaa = "02"))
                 )
             ) shouldBe AnsattEnhetV1Result(
@@ -25,7 +25,7 @@ class ResultMapperTest : ShouldSpec({
     context("success - multiple elements") {
         should("map  to a multi-element AnsattEnhetV1Tjenestekontor list") {
             ResultMapper.toDto(
-                source = AnsattEnhetResult(
+                source = TjenestekontorEnheter(
                     enhetListe =
                         listOf(
                             TjenestekontorEnhet(id = "1001", navn = "Kontor A", nivaa = "02"),
@@ -46,7 +46,7 @@ class ResultMapperTest : ShouldSpec({
 
     context("failure - empty list") {
         should("map an empty TjenestekontorEnhet list to an empty AnsattEnhetV1Tjenestekontor list") {
-            ResultMapper.toDto(source = AnsattEnhetResult(enhetListe = emptyList())) shouldBe
+            ResultMapper.toDto(source = TjenestekontorEnheter(enhetListe = emptyList())) shouldBe
                     AnsattEnhetV1Result(enhetListe = emptyList(), problem = null)
         }
     }
@@ -54,7 +54,7 @@ class ResultMapperTest : ShouldSpec({
     context("failure - ansatt not found") {
         should("map the problem to a problem DTO") {
             ResultMapper.toDto(
-                source = AnsattEnhetResult(
+                source = TjenestekontorEnheter(
                     enhetListe = emptyList(),
                     problem = Problem(
                         type = ProblemType.PERSON_IKKE_FUNNET,

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/api/v1/acl/ResultMapperTest.kt
@@ -1,0 +1,73 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.api.v1.acl
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
+import no.nav.pensjon.kalkulator.validity.Problem
+import no.nav.pensjon.kalkulator.validity.ProblemType
+
+class ResultMapperTest : ShouldSpec({
+
+    context("success - single element") {
+        should("map to a single-element AnsattEnhetV1Tjenestekontor list") {
+            ResultMapper.toDto(
+                source = AnsattEnhetResult(
+                    enhetListe = listOf(TjenestekontorEnhet(id = "1001", navn = "Kontor A", nivaa = "02"))
+                )
+            ) shouldBe AnsattEnhetV1Result(
+                enhetListe = listOf(AnsattEnhetV1Tjenestekontor(id = "1001", navn = "Kontor A")),
+                problem = null
+            )
+        }
+    }
+
+    context("success - multiple elements") {
+        should("map  to a multi-element AnsattEnhetV1Tjenestekontor list") {
+            ResultMapper.toDto(
+                source = AnsattEnhetResult(
+                    enhetListe =
+                        listOf(
+                            TjenestekontorEnhet(id = "1001", navn = "Kontor A", nivaa = "02"),
+                            TjenestekontorEnhet(id = "1002", navn = "Kontor B", nivaa = "03"),
+                            TjenestekontorEnhet(id = "1003", navn = "Kontor C", nivaa = "01")
+                        )
+                )
+            ) shouldBe AnsattEnhetV1Result(
+                enhetListe = listOf(
+                    AnsattEnhetV1Tjenestekontor(id = "1001", navn = "Kontor A"),
+                    AnsattEnhetV1Tjenestekontor(id = "1002", navn = "Kontor B"),
+                    AnsattEnhetV1Tjenestekontor(id = "1003", navn = "Kontor C")
+                ),
+                problem = null
+            )
+        }
+    }
+
+    context("failure - empty list") {
+        should("map an empty TjenestekontorEnhet list to an empty AnsattEnhetV1Tjenestekontor list") {
+            ResultMapper.toDto(source = AnsattEnhetResult(enhetListe = emptyList())) shouldBe
+                    AnsattEnhetV1Result(enhetListe = emptyList(), problem = null)
+        }
+    }
+
+    context("failure - ansatt not found") {
+        should("map the problem to a problem DTO") {
+            ResultMapper.toDto(
+                source = AnsattEnhetResult(
+                    enhetListe = emptyList(),
+                    problem = Problem(
+                        type = ProblemType.PERSON_IKKE_FUNNET,
+                        beskrivelse = "User with ID X123456 not found"
+                    )
+                )
+            ) shouldBe
+                    AnsattEnhetV1Result(
+                        enhetListe = emptyList(), problem = AnsattEnhetV1Problem(
+                            kode = AnsattEnhetV1ProblemType.ANSATT_IKKE_FUNNET,
+                            beskrivelse = "User with ID X123456 not found"
+                        )
+                    )
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClientTest.kt
@@ -1,0 +1,122 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
+import no.nav.pensjon.kalkulator.tech.trace.TraceAid
+import no.nav.pensjon.kalkulator.testutil.Arrange
+import no.nav.pensjon.kalkulator.testutil.arrangeJsonResponse
+import no.nav.pensjon.kalkulator.testutil.arrangeOkJsonResponse
+import no.nav.pensjon.kalkulator.validity.Problem
+import no.nav.pensjon.kalkulator.validity.ProblemType
+import okhttp3.mockwebserver.MockWebServer
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.getBean
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClient
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+
+class NavAnsattClientTest : ShouldSpec({
+
+    var server: MockWebServer? = null
+    var baseUrl: String? = null
+    val traceAid = mockk<TraceAid>(relaxed = true)
+
+    fun client(context: BeanFactory, jsonMapper: JsonMapper) =
+        NavAnsattClient(
+            baseUrl!!,
+            retryAttempts = "1",
+            webClientBuilder = context.getBean<WebClient.Builder>(),
+            cacheManager = CaffeineCacheManager(),
+            jsonMapper,
+            traceAid
+        )
+
+    beforeSpec {
+        Arrange.security()
+        server = MockWebServer().apply { start() }
+        baseUrl = "http://localhost:${server.port}"
+    }
+
+    afterSpec {
+        server?.shutdown()
+    }
+
+    should("return enhetsliste when service returns 200 OK") {
+        server?.arrangeOkJsonResponse(
+            body = """[
+                {
+                    "id": "4833",
+                    "navn": "Nav familie- og pensjonsytelser Oslo 1",
+                    "nivaa": "EN"
+                },
+                {
+                    "id": "4475",
+                    "navn": "Nav arbeid og ytelser - uføretrygd bosatt utland",
+                    "nivaa": "SPESEN"
+                },
+                {
+                    "id": "4415",
+                    "navn": "Nav arbeid og ytelser Møre og Romsdal",
+                    "nivaa": "EN"
+                }
+            ]"""
+        )
+
+        Arrange.webClientContextRunner().run {
+            client(context = it, jsonMapper).fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) shouldBe
+                    AnsattEnhetResult(
+                        listOf(
+                            TjenestekontorEnhet(
+                                id = "4833",
+                                navn = "Nav familie- og pensjonsytelser Oslo 1",
+                                nivaa = "EN"
+                            ),
+                            TjenestekontorEnhet(
+                                id = "4475",
+                                navn = "Nav arbeid og ytelser - uføretrygd bosatt utland",
+                                nivaa = "SPESEN"
+                            ),
+                            TjenestekontorEnhet(
+                                id = "4415",
+                                navn = "Nav arbeid og ytelser Møre og Romsdal",
+                                nivaa = "EN"
+                            )
+                        ),
+                        problem = null
+                    )
+        }
+    }
+
+    should("return problem with details when service returns 404 Not Found") {
+        server?.arrangeJsonResponse(
+            status = HttpStatus.NOT_FOUND,
+            body = """{"message":"User with ID $ANSATT_ID not found"}"""
+        )
+
+        Arrange.webClientContextRunner().run {
+            client(
+                context = it,
+                jsonMapper
+            ).fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) shouldBe
+                    AnsattEnhetResult(
+                        enhetListe = emptyList(),
+                        problem = Problem(
+                            type = ProblemType.PERSON_IKKE_FUNNET,
+                            beskrivelse = "User with ID $ANSATT_ID not found"
+                        )
+                    )
+        }
+    }
+})
+
+private const val ANSATT_ID = "X123456"
+
+private val jsonMapper: JsonMapper =
+    JsonMapper.builder()
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .build()

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/NavAnsattClientTest.kt
@@ -3,7 +3,7 @@ package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
-import no.nav.pensjon.kalkulator.ansatt.enhet.AnsattEnhetResult
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnheter
 import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.testutil.Arrange
@@ -69,7 +69,7 @@ class NavAnsattClientTest : ShouldSpec({
 
         Arrange.webClientContextRunner().run {
             client(context = it, jsonMapper).fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) shouldBe
-                    AnsattEnhetResult(
+                    TjenestekontorEnheter(
                         listOf(
                             TjenestekontorEnhet(
                                 id = "4833",
@@ -103,7 +103,7 @@ class NavAnsattClientTest : ShouldSpec({
                 context = it,
                 jsonMapper
             ).fetchTjenestekontorEnhetListe(ansattId = ANSATT_ID) shouldBe
-                    AnsattEnhetResult(
+                    TjenestekontorEnheter(
                         enhetListe = emptyList(),
                         problem = Problem(
                             type = ProblemType.PERSON_IKKE_FUNNET,

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/ansatt/enhet/client/navansatt/acl/NavEnhetResultMapperTest.kt
@@ -1,0 +1,34 @@
+package no.nav.pensjon.kalkulator.ansatt.enhet.client.navansatt.acl
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.kalkulator.ansatt.enhet.TjenestekontorEnhet
+
+class NavEnhetResultMapperTest : ShouldSpec({
+
+    context("fromDto function") {
+        should("map an empty DTO list to an empty TjenestekontorEnhet list") {
+            NavEnhetResultMapper.fromDto(emptyList()).enhetListe shouldBe emptyList()
+        }
+
+        should("map a single-element DTO list to a single-element TjenestekontorEnhet list") {
+            NavEnhetResultMapper.fromDto(
+                listOf(NavEnhetResultDto(id = "1001", navn = "Kontor A", nivaa = "02"))
+            ).enhetListe shouldBe listOf(TjenestekontorEnhet(id = "1001", navn = "Kontor A", nivaa = "02"))
+        }
+
+        should("map a multi-element DTO list to a multi-element TjenestekontorEnhet list") {
+            NavEnhetResultMapper.fromDto(
+                listOf(
+                    NavEnhetResultDto(id = "1001", navn = "Kontor A", nivaa = "02"),
+                    NavEnhetResultDto(id = "1002", navn = "Kontor B", nivaa = "03"),
+                    NavEnhetResultDto(id = "1003", navn = "Kontor C", nivaa = "01")
+                )
+            ).enhetListe shouldBe listOf(
+                TjenestekontorEnhet(id = "1001", navn = "Kontor A", nivaa = "02"),
+                TjenestekontorEnhet(id = "1002", navn = "Kontor B", nivaa = "03"),
+                TjenestekontorEnhet(id = "1003", navn = "Kontor C", nivaa = "01")
+            )
+        }
+    }
+})


### PR DESCRIPTION
Henter liste over enheter (tjenestekontor) som den innloggede Nav-ansatte er tilknyttet.
Det hentes fra tjenesten [navansatt](https://github.com/navikt/navansatt).
Listen tilbys til frontend via et nytt endepunkt: `/api/intern/v1/enheter`.