### PR TITLE
TPP-501 Drop 'fullmakt' check when 'veileder' logged in

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
@@ -93,11 +93,10 @@ class PensjonRepresentasjonClient(
 
         private val representasjonTypeListe: List<String> =
             listOf(
-                "PENSJON_FULLSTENDIG",
+                "PENSJON_LES",
                 "PENSJON_SKRIV",
-                "PENSJON_PENGEMOTTAKER",
-                "PENSJON_VERGE",
-                "PENSJON_VERGE_PENGEMOTTAKER"
+                "VERGE_PENSJON_LES",
+                "VERGE_PENSJON_SKRIV"
             )
 
         private val service = EgressService.PENSJON_REPRESENTASJON

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricher.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricher.kt
@@ -31,8 +31,11 @@ class SecurityContextEnricher(
             if (authentication == null) {
                 authentication = anonymousAuthentication()
             } else {
-                authentication = enrich(authentication!!, request)
-                authentication = applyPotentialFullmakt(authentication!!, request)
+                authentication = authentication?.let { enrich(it, request) }
+
+                if (authentication?.enriched()?.veilederInnlogget() != true) {
+                    authentication = authentication?.let { applyPotentialFullmakt(it, request) }
+                }
             }
         }
     }
@@ -73,7 +76,10 @@ class SecurityContextEnricher(
      * Dette fordi pensjon-representasjon henter ut PID fra TokenX-tokenet (som ikke finnes når veileder er logget inn).
      */
     private fun validRepresentasjonForhold(pid: Pid) =
-        representasjonService.hasValidRepresentasjonsforhold(pid).isValid
+        if (pid.isValid)
+            representasjonService.hasValidRepresentasjonsforhold(pid).isValid
+        else
+            false
 
     private fun enrichWithFullmakt(auth: Authentication, fullmaktGiverPid: Pid) =
         EnrichedAuthentication(
@@ -111,8 +117,14 @@ class SecurityContextEnricher(
     private fun onBehalfOfPid(cookies: Array<Cookie>?): Pid? =
         cookies.orEmpty()
             .filter { ON_BEHALF_OF_COOKIE_NAME.equals(it.name, ignoreCase = true) }
-            .map { Pid(it.value) }
+            .map { Pid((decrypt(it.value.orEmpty()))) }
             .firstOrNull()
+
+    private fun decrypt(value: String): String =
+        if (value.contains(ENCRYPTION_MARK))
+            pidDecrypter.decrypt(value)
+        else
+            value
 
     private companion object {
         private const val ENCRYPTION_MARK = "."

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
@@ -9,6 +9,7 @@ import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.testutil.Arrange
 import no.nav.pensjon.kalkulator.testutil.arrangeOkJsonResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.springframework.beans.factory.getBean
 import org.springframework.web.reactive.function.client.WebClient
 
 class PensjonRepresentasjonClientTest : FunSpec({
@@ -32,7 +33,7 @@ class PensjonRepresentasjonClientTest : FunSpec({
         Arrange.webClientContextRunner().run {
             val client = PensjonRepresentasjonClient(
                 baseUrl = baseUrl!!,
-                webClientBuilder = it.getBean(WebClient.Builder::class.java),
+                webClientBuilder = it.getBean<WebClient.Builder>(),
                 traceAid = mockk<TraceAid>(relaxed = true),
                 retryAttempts = "0"
             )
@@ -40,11 +41,11 @@ class PensjonRepresentasjonClientTest : FunSpec({
             client.hasValidRepresentasjonsforhold(pid) shouldBe
                     Representasjon(isValid = true, fullmaktGiverNavn = "Abc Æøå")
 
-            server.takeRequest().requestUrl?.query shouldBe "validRepresentasjonstyper=PENSJON_FULLSTENDIG" +
+            server.takeRequest().requestUrl?.query shouldBe
+                    "validRepresentasjonstyper=PENSJON_LES" +
                     "&validRepresentasjonstyper=PENSJON_SKRIV" +
-                    "&validRepresentasjonstyper=PENSJON_PENGEMOTTAKER" +
-                    "&validRepresentasjonstyper=PENSJON_VERGE" +
-                    "&validRepresentasjonstyper=PENSJON_VERGE_PENGEMOTTAKER" +
+                    "&validRepresentasjonstyper=VERGE_PENSJON_LES" +
+                    "&validRepresentasjonstyper=VERGE_PENSJON_SKRIV" +
                     "&includeFullmaktsgiverNavn=false"
         }
     }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricherTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricherTest.kt
@@ -14,6 +14,8 @@ import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonService
+import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonTarget
+import no.nav.pensjon.kalkulator.tech.representasjon.RepresentertRolle
 import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressTokenSuppliersByService
 import no.nav.pensjon.kalkulator.tech.security.ingress.SecurityContextPidExtractor
 import org.springframework.security.core.Authentication
@@ -70,11 +72,11 @@ class SecurityContextEnricherTest : ShouldSpec({
             pidDecrypter = arrangeDecryption(),
             representasjonService = mockk()
         ).enrichAuthentication(
-            request = arrangeFoedselsnummer("encrypted.string.containing.dot"), // encrypted PID
+            request = arrangeFoedselsnummer(ENCRYPTED_PID),
             response = mockk()
         )
 
-        securityContextTargetPid()?.value shouldBe "12906498357"
+        securityContextTargetPid()?.value shouldBe PID
     }
 
     should("use plaintext PID if not encrypted") {
@@ -86,76 +88,129 @@ class SecurityContextEnricherTest : ShouldSpec({
             pidDecrypter = mockk(),
             representasjonService = mockk()
         ).enrichAuthentication(
-            request = arrangeFoedselsnummer("12906498357"), // not encrypted
+            request = arrangeFoedselsnummer(PID), // not encrypted
             response = mockk()
         )
 
-        securityContextTargetPid()?.value shouldBe "12906498357"
+        securityContextTargetPid()?.value shouldBe PID
     }
 
-    should("set target PID from OBO cookie if valid representasjon") {
-        setSecurityContext(authentication = mockk())
+    context("valid representasjon") {
+        should("set target PID from plaintext OBO cookie") {
+            setSecurityContext(authentication = mockk())
 
-        SecurityContextEnricher(
-            tokenSuppliers,
-            securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
-            pidDecrypter = mockk(),
-            representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
-        ).enrichAuthentication(
-            request = arrangeOnBehalfOfCookie(),
-            response = mockk()
-        )
-
-        securityContextTargetPid()?.value shouldBe "12906498357"
-    }
-
-    should("throw AccessDeniedException if invalid representasjon") {
-        setSecurityContext(authentication = mockk())
-
-        shouldThrow<org.springframework.security.access.AccessDeniedException> {
             SecurityContextEnricher(
                 tokenSuppliers,
                 securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
                 pidDecrypter = mockk(),
-                representasjonService = arrange(Representasjon(isValid = false, fullmaktGiverNavn = ""))
+                representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
             ).enrichAuthentication(
-                request = arrangeOnBehalfOfCookie(),
+                request = arrangeOnBehalfOfCookie(PID),
                 response = mockk()
             )
-        }.message shouldBe "INVALID_REPRESENTASJON"
 
-        securityContextTargetPid()?.value shouldBe null
+            securityContextTargetPid()?.value shouldBe PID
+        }
+
+        should("set target PID from encrypted OBO cookie") {
+            setSecurityContext(authentication = mockk())
+
+            SecurityContextEnricher(
+                tokenSuppliers,
+                securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
+                pidDecrypter = arrangeDecryption(),
+                representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
+            ).enrichAuthentication(
+                request = arrangeOnBehalfOfCookie(ENCRYPTED_PID),
+                response = mockk()
+            )
+
+            securityContextTargetPid()?.value shouldBe PID
+        }
+    }
+
+    context("invalid representasjon") {
+        should("throw AccessDeniedException") {
+            setSecurityContext(authentication = mockk())
+
+            shouldThrow<org.springframework.security.access.AccessDeniedException> {
+                SecurityContextEnricher(
+                    tokenSuppliers,
+                    securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
+                    pidDecrypter = mockk(),
+                    representasjonService = arrange(Representasjon(isValid = false, fullmaktGiverNavn = ""))
+                ).enrichAuthentication(
+                    request = arrangeOnBehalfOfCookie(PID),
+                    response = mockk()
+                )
+            }.message shouldBe "INVALID_REPRESENTASJON"
+
+            securityContextTargetPid()?.value shouldBe null
+        }
+    }
+
+    context("person under veiledning") {
+        should("not check representasjonsforhold despite presence of OBO cookie") {
+            setSecurityContext(
+                authentication = EnrichedAuthentication(
+                    initialAuth = mockk(),
+                    egressTokenSuppliersByService = tokenSuppliers,
+                    target = RepresentasjonTarget(pid, rolle = RepresentertRolle.UNDER_VEILEDNING)
+                )
+            )
+            val securityContextPidExtractor = mockk<SecurityContextPidExtractor>(relaxed = true)
+            val representasjonService = mockk<RepresentasjonService>(relaxed = true)
+
+            SecurityContextEnricher(
+                tokenSuppliers,
+                securityContextPidExtractor,
+                pidDecrypter = mockk(),
+                representasjonService
+            ).enrichAuthentication(
+                request = arrangeOnBehalfOfCookieAndHeader(),
+                response = mockk()
+            )
+
+            verify(exactly = 0) { representasjonService.hasValidRepresentasjonsforhold(any()) }
+        }
     }
 })
+
+private const val PID = "12906498357"
+private const val ENCRYPTED_PID = "contains.dot"
 
 private fun setSecurityContext(authentication: Authentication) {
     SecurityContextHolder.setContext(SecurityContextImpl(authentication))
 }
 
-private fun securityContextTargetPid() =
+private fun securityContextTargetPid(): Pid? =
     SecurityContextHolder.getContext().authentication?.enriched()?.targetPid()
 
-private fun arrangeFoedselsnummer(value: String?) =
+private fun arrangeFoedselsnummer(value: String?): HttpServletRequest =
     mockk<HttpServletRequest>(relaxed = true).apply {
         every { getHeader("fnr") } returns value
     }
 
-private fun arrangeOnBehalfOfCookie() =
+private fun arrangeOnBehalfOfCookie(value: String): HttpServletRequest =
     mockk<HttpServletRequest>(relaxed = true).apply {
-        every { cookies } returns listOf(Cookie("nav-obo", "12906498357")).toTypedArray()
+        every { cookies } returns listOf(Cookie("nav-obo", value)).toTypedArray()
     }
 
-private fun arrange(representasjon: Representasjon) =
-    mockk<RepresentasjonService>().apply {
-        every { hasValidRepresentasjonsforhold(Pid("12906498357")) } returns representasjon
+private fun arrangeOnBehalfOfCookieAndHeader(): HttpServletRequest =
+    mockk<HttpServletRequest>(relaxed = true).apply {
+        every { getHeader("fnr") } returns PID
+        every { cookies } returns listOf(Cookie("nav-obo", PID)).toTypedArray()
     }
 
-private fun arrangeDecryption() =
-    mockk<CryptoService>().apply {
-        every { decrypt("encrypted.string.containing.dot") } returns "12906498357"
+private fun arrange(representasjon: Representasjon): RepresentasjonService =
+    mockk {
+        every {
+            hasValidRepresentasjonsforhold(fullmaktGiverPid = Pid(PID))
+        } returns representasjon
     }
+
+private fun arrangeDecryption(): CryptoService =
+    mockk { every { decrypt(ENCRYPTED_PID) } returns PID }
 
 private fun arrangeSecurityContextPidExtractor(): SecurityContextPidExtractor =
-    mockk<SecurityContextPidExtractor>().apply {
-        every { pid() } returns null
-    }
+    mockk { every { pid() } returns null }


### PR DESCRIPTION
- Dropper fullmaktsjekk når veileder er innlogget (representasjon er irrelevant i veileder-modus)
- Støtter kryptert OBO-cookie
- Oppdaterer liste over representasjonstyper