### PR TITLE
TPP-479 Use 'kjerneregler' in EPS access check

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/EpsService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/EpsService.kt
@@ -2,11 +2,15 @@ package no.nav.pensjon.kalkulator.person.relasjon.eps
 
 import no.nav.pensjon.kalkulator.person.PersonService
 import no.nav.pensjon.kalkulator.person.PersonaliaType
+import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.person.Sivilstand
 import no.nav.pensjon.kalkulator.person.Sivilstatus
 import no.nav.pensjon.kalkulator.person.relasjon.Familierelasjon
 import no.nav.pensjon.kalkulator.person.relasjon.Relasjonstype
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.EpsClient
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.NaavaerendeEpsSpec
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.NyligsteEpsSpec
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.TidligereStatusSpec
 import no.nav.pensjon.kalkulator.tech.security.ingress.PidGetter
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.access.folk.CacheAwarePopulasjonstilgangService
 import no.nav.pensjon.kalkulator.tech.web.EgressException
@@ -35,39 +39,36 @@ class EpsService(
      */
     fun nyligsteRelasjon(sivilstatus: Sivilstatus): Familierelasjon {
         val eps: Familierelasjon = client.fetchNyligsteEps(
-            soekerPid = pidGetter.pid(),
-            sivilstatus,
-            personaliaSpec
+            spec = NyligsteEpsSpec(
+                soekerPid = pidGetter.pid(),
+                sivilstatus,
+                personalia = personaliaSpec
+            )
         )
 
-        eps.pid?.let(populasjonstilgangService::eventuellTilgangsnektAarsak)?.let {
-            throw AccessDeniedException("Tilgang til EPS nektet: $it")
-        }
+        eps.pid?.let(::eventuellTilgangsnektAarsak)
+            ?.let { throw AccessDeniedException("Tilgang til EPS nektet: $it") }
 
         return eps
     }
 
-    fun tidligereGiftEllerBarnMedSamboer(): Boolean? {
-        val eps = hentNaavaerendeEps()
-
-        return if (
-            eps?.relasjonstype == Relasjonstype.SAMBOER &&
-            eps.pid != null
-        ) {
-            client.fetchTidligereGiftEllerBarnMed(
-                soekerPid = pidGetter.pid(),
-                samboerPid = eps.pid
-            )
-        } else {
-            null
+    fun tidligereGiftEllerBarnMedSamboer(): Boolean? =
+        hentNaavaerendeEps()?.let {
+            if (it.relasjonstype == Relasjonstype.SAMBOER && it.pid != null)
+                erTidligereGiftEllerHarBarnMed(it.pid)
+            else
+                null
         }
-    }
+
+    private fun erTidligereGiftEllerHarBarnMed(pid: Pid): Boolean =
+        client.fetchTidligereGiftEllerBarnMed(
+            spec = TidligereStatusSpec(soekerPid = pidGetter.pid(), samboerPid = pid)
+        )
 
     private fun hentNaavaerendeEps() =
         try {
             client.fetchNaavaerendeEps(
-                soekerPid = pidGetter.pid(),
-                personaliaSpec
+                spec = NaavaerendeEpsSpec(soekerPid = pidGetter.pid(), personalia = personaliaSpec)
             )
         } catch (e: EgressException) {
             if (e.statusCode == HttpStatus.NOT_FOUND) {
@@ -80,13 +81,17 @@ class EpsService(
     private fun relasjonstype(): Relasjonstype =
         hentNaavaerendeEps()?.relasjonstype ?: Relasjonstype.UKJENT
 
+    private fun eventuellTilgangsnektAarsak(pid: Pid): String? =
+        populasjonstilgangService.eventuellTilgangsnektAarsak(pid = pid, sjekkKunKjerneregler = true)
+
     private companion object {
-        private val personaliaSpec: List<PersonaliaType> = listOf(
-            PersonaliaType.NAVN,
-            PersonaliaType.FOEDSELSDATO,
-            PersonaliaType.DOEDSDATO,
-            PersonaliaType.STATSBORGERSKAP
-        )
+        private val personaliaSpec: List<PersonaliaType> =
+            listOf(
+                PersonaliaType.NAVN,
+                PersonaliaType.FOEDSELSDATO,
+                PersonaliaType.DOEDSDATO,
+                PersonaliaType.STATSBORGERSKAP
+            )
 
         private fun sivilstatus(registrertSivilstand: Sivilstand?, harSamboer: Boolean): Sivilstatus? =
             when {

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/EpsClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/EpsClient.kt
@@ -1,8 +1,5 @@
 package no.nav.pensjon.kalkulator.person.relasjon.eps.client
 
-import no.nav.pensjon.kalkulator.person.PersonaliaType
-import no.nav.pensjon.kalkulator.person.Pid
-import no.nav.pensjon.kalkulator.person.Sivilstatus
 import no.nav.pensjon.kalkulator.person.relasjon.Familierelasjon
 
 /**
@@ -10,19 +7,9 @@ import no.nav.pensjon.kalkulator.person.relasjon.Familierelasjon
  */
 interface EpsClient {
 
-    fun fetchNaavaerendeEps(
-        soekerPid: Pid,
-        personaliaSpec: List<PersonaliaType>
-    ): Familierelasjon
+    fun fetchNaavaerendeEps(spec: NaavaerendeEpsSpec): Familierelasjon
 
-    fun fetchNyligsteEps(
-        soekerPid: Pid,
-        sivilstatus: Sivilstatus,
-        personaliaSpec: List<PersonaliaType>
-    ): Familierelasjon
+    fun fetchNyligsteEps(spec: NyligsteEpsSpec): Familierelasjon
 
-    fun fetchTidligereGiftEllerBarnMed(
-        soekerPid: Pid,
-        samboerPid: Pid,
-    ): Boolean
+    fun fetchTidligereGiftEllerBarnMed(spec: TidligereStatusSpec): Boolean
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/EpsSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/EpsSpec.kt
@@ -1,0 +1,21 @@
+package no.nav.pensjon.kalkulator.person.relasjon.eps.client
+
+import no.nav.pensjon.kalkulator.person.PersonaliaType
+import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.person.Sivilstatus
+
+data class NaavaerendeEpsSpec(
+    val soekerPid: Pid,
+    val personalia: List<PersonaliaType>
+)
+
+data class NyligsteEpsSpec(
+    val soekerPid: Pid,
+    val sivilstatus: Sivilstatus,
+    val personalia: List<PersonaliaType>
+)
+
+data class TidligereStatusSpec(
+    val soekerPid: Pid,
+    val samboerPid: Pid
+)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClient.kt
@@ -51,8 +51,8 @@ class PensjonPersondataClient(
     private val webClient = webClientBuilder.baseUrl(baseUrl).build()
     private val log = KotlinLogging.logger {}
 
-    private val naavarendeEpsCache: Cache<NaavaerendeEpsSpec, Familierelasjon> =
-        createCache("naavaerendEps", cacheManager)
+    private val naavaerendeEpsCache: Cache<NaavaerendeEpsSpec, Familierelasjon> =
+        createCache("naavaerendeEps", cacheManager)
 
     private val nyligsteEpsCache: Cache<NyligsteEpsSpec, Familierelasjon> =
         createCache("nyligsteEps", cacheManager)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClient.kt
@@ -1,18 +1,21 @@
 package no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd
 
+import com.github.benmanes.caffeine.cache.Cache
 import mu.KotlinLogging
 import no.nav.pensjon.kalkulator.common.client.ExternalServiceClient
-import no.nav.pensjon.kalkulator.person.PersonaliaType
 import no.nav.pensjon.kalkulator.person.Pid
-import no.nav.pensjon.kalkulator.person.Sivilstatus
 import no.nav.pensjon.kalkulator.person.relasjon.Familierelasjon
 import no.nav.pensjon.kalkulator.person.relasjon.Relasjonstype
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.EpsClient
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.NaavaerendeEpsSpec
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.NyligsteEpsSpec
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.TidligereStatusSpec
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd.acl.TidligereGiftEllerBarnMedDto
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd.acl.FamilierelasjonDto
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd.acl.FamilierelasjonMapper
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd.acl.PersonaliaTypeDto
 import no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd.acl.RelasjonstypeDto
+import no.nav.pensjon.kalkulator.tech.cache.CacheConfigurator.createCache
 import no.nav.pensjon.kalkulator.tech.metric.MetricResult
 import no.nav.pensjon.kalkulator.tech.security.egress.EgressAccess
 import no.nav.pensjon.kalkulator.tech.security.egress.config.EgressService
@@ -23,6 +26,7 @@ import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.tech.web.CustomHttpHeaders
 import no.nav.pensjon.kalkulator.tech.web.EgressException
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -39,6 +43,7 @@ import org.springframework.web.reactive.function.client.bodyToMono
 class PensjonPersondataClient(
     @param:Value($$"${pensjon-persondata.url}") private val baseUrl: String,
     webClientBuilder: WebClient.Builder,
+    cacheManager: CaffeineCacheManager,
     private val traceAid: TraceAid,
     @Value($$"${web-client.retry-attempts}") retryAttempts: String
 ) : ExternalServiceClient(retryAttempts), EpsClient, Pingable {
@@ -46,21 +51,39 @@ class PensjonPersondataClient(
     private val webClient = webClientBuilder.baseUrl(baseUrl).build()
     private val log = KotlinLogging.logger {}
 
+    private val naavarendeEpsCache: Cache<NaavaerendeEpsSpec, Familierelasjon> =
+        createCache("naavaerendEps", cacheManager)
+
+    private val nyligsteEpsCache: Cache<NyligsteEpsSpec, Familierelasjon> =
+        createCache("nyligsteEps", cacheManager)
+
+    private val tidligereStatusCache: Cache<TidligereStatusSpec, Boolean> =
+        createCache("tidligereStatus", cacheManager)
+
     override fun service() = service
 
-    override fun fetchNaavaerendeEps(
-        soekerPid: Pid,
-        personaliaSpec: List<PersonaliaType>
-    ): Familierelasjon {
+    override fun fetchNaavaerendeEps(spec: NaavaerendeEpsSpec): Familierelasjon =
+        naavarendeEpsCache.getIfPresent(spec)
+            ?: fetchFreshNaavaerendeEps(spec).also { naavarendeEpsCache.put(spec, it) }
+
+    override fun fetchNyligsteEps(spec: NyligsteEpsSpec): Familierelasjon =
+        nyligsteEpsCache.getIfPresent(spec)
+            ?: fetchFreshNyligsteEps(spec).also { nyligsteEpsCache.put(spec, it) }
+
+    override fun fetchTidligereGiftEllerBarnMed(spec: TidligereStatusSpec): Boolean =
+        tidligereStatusCache.getIfPresent(spec)
+            ?: fetchFreshTidligereGiftEllerBarnMed(spec).also { tidligereStatusCache.put(spec, it) }
+
+    private fun fetchFreshNaavaerendeEps(spec: NaavaerendeEpsSpec): Familierelasjon {
         val uri = "/$NAAVAERENDE_EPS_PATH"
         val url = "$baseUrl$uri"
-        val body: List<String> = personaliaSpec.map(PersonaliaTypeDto::externalValue)
+        val body: List<String> = spec.personalia.map(PersonaliaTypeDto::externalValue)
 
         return try {
             webClient
                 .post()
                 .uri(uri)
-                .headers { setHeaders(headers = it, soekerPid) }
+                .headers { setHeaders(headers = it, spec.soekerPid) }
                 .bodyValue(body)
                 .retrieve()
                 .bodyToMono<FamilierelasjonDto>()
@@ -74,13 +97,13 @@ class PensjonPersondataClient(
             throw EgressException(e.responseBodyAsString, e)
         } catch (e: EgressException) {
             if (e.statusCode == HttpStatus.NOT_FOUND)
-                emptyFamilierelasjon.also { log.info { "$url ga status ${e.statusCode} for pid $soekerPid" } }
+                emptyFamilierelasjon.also { log.info { "$url ga status ${e.statusCode} for pid ${spec.soekerPid}" } }
             else
                 throw e
         }
     }
 
-    override fun fetchTidligereGiftEllerBarnMed(soekerPid: Pid, samboerPid: Pid): Boolean {
+    private fun fetchFreshTidligereGiftEllerBarnMed(spec: TidligereStatusSpec): Boolean {
         val uri = "/$TIDLIGERE_GIFT_ELLER_BARN_MED_PATH"
         val url = "$baseUrl$uri"
 
@@ -88,7 +111,7 @@ class PensjonPersondataClient(
             webClient
                 .get()
                 .uri(uri)
-                .headers { setHeaders(headers = it, soekerPid, samboerPid) }
+                .headers { setHeaders(headers = it, spec.soekerPid, spec.samboerPid) }
                 .retrieve()
                 .bodyToMono<TidligereGiftEllerBarnMedDto>()
                 .retryWhen(retryBackoffSpec(url))
@@ -102,28 +125,26 @@ class PensjonPersondataClient(
         } catch (e: EgressException) {
             if (e.statusCode == HttpStatus.NOT_FOUND)
                 false.also {
-                    log.info { "$url ga status ${e.statusCode} for soekerPid $soekerPid samboerPid $samboerPid" }
+                    log.info {
+                        "$url ga status ${e.statusCode} for soekerPid ${spec.soekerPid} samboerPid ${spec.samboerPid}"
+                    }
                 }
             else
                 throw e
         }
     }
 
-    override fun fetchNyligsteEps(
-        soekerPid: Pid,
-        sivilstatus: Sivilstatus,
-        personaliaSpec: List<PersonaliaType>
-    ): Familierelasjon {
-        val relasjonstype = RelasjonstypeDto.fromSivilstatus(sivilstatus)
+    private fun fetchFreshNyligsteEps(spec: NyligsteEpsSpec): Familierelasjon {
+        val relasjonstype = RelasjonstypeDto.fromSivilstatus(spec.sivilstatus)
         val uri = "/$NYLIGSTE_EPS_PATH?epsType=${relasjonstype.name}"
         val url = "$baseUrl$uri"
-        val body: List<String> = personaliaSpec.map(PersonaliaTypeDto::externalValue)
+        val body: List<String> = spec.personalia.map(PersonaliaTypeDto::externalValue)
 
         return try {
             webClient
                 .post()
                 .uri(uri)
-                .headers { setHeaders(headers = it, soekerPid) }
+                .headers { setHeaders(headers = it, spec.soekerPid) }
                 .bodyValue(body)
                 .retrieve()
                 .bodyToMono<FamilierelasjonDto>()
@@ -137,7 +158,7 @@ class PensjonPersondataClient(
             throw EgressException(e.responseBodyAsString, e)
         } catch (e: EgressException) {
             if (e.statusCode == HttpStatus.NOT_FOUND)
-                emptyFamilierelasjon.also { log.info { "$url ga status ${e.statusCode} for pid $soekerPid" } }
+                emptyFamilierelasjon.also { log.info { "$url ga status ${e.statusCode} for pid ${spec.soekerPid}" } }
             else
                 throw e
         }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClient.kt
@@ -63,8 +63,8 @@ class PensjonPersondataClient(
     override fun service() = service
 
     override fun fetchNaavaerendeEps(spec: NaavaerendeEpsSpec): Familierelasjon =
-        naavarendeEpsCache.getIfPresent(spec)
-            ?: fetchFreshNaavaerendeEps(spec).also { naavarendeEpsCache.put(spec, it) }
+        naavaerendeEpsCache.getIfPresent(spec)
+            ?: fetchFreshNaavaerendeEps(spec).also { naavaerendeEpsCache.put(spec, it) }
 
     override fun fetchNyligsteEps(spec: NyligsteEpsSpec): Familierelasjon =
         nyligsteEpsCache.getIfPresent(spec)

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/CacheAwarePopulasjonstilgangService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/CacheAwarePopulasjonstilgangService.kt
@@ -22,9 +22,9 @@ class CacheAwarePopulasjonstilgangService(
         .build()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    fun eventuellTilgangsnektAarsak(pid: Pid): String? =
+    fun eventuellTilgangsnektAarsak(pid: Pid, sjekkKunKjerneregler: Boolean = false): String? =
         try {
-            with(populasjonstilgang(pid)) {
+            with(populasjonstilgang(pid, sjekkKunKjerneregler)) {
                 if (innvilget) null
                 else avvisningsinfo
             }
@@ -32,16 +32,16 @@ class CacheAwarePopulasjonstilgangService(
             "${AvvisningAarsak.POPULASJONSTILGANGSSJEKK_FEILET}: ${e.message}".also { log.error(e) { it } }
         }
 
-    private fun populasjonstilgang(pid: Pid): TilgangResult {
-        val deferred = tilgangCache.get(cacheKey(pid)) {
+    private fun populasjonstilgang(pid: Pid, sjekkKunKjerneregler: Boolean): TilgangResult {
+        val deferred = tilgangCache.get(cacheKey(pid, sjekkKunKjerneregler)) {
             scope.async(SecurityCoroutineContext()) {
-                populasjonstilgangService.sjekkTilgang(pid)
+                populasjonstilgangService.sjekkTilgang(pid, sjekkKunKjerneregler)
             }
         }
 
         return runBlocking { deferred.await() }
     }
 
-    private fun cacheKey(pid: Pid): String =
-        "${navIdExtractor.id()}:${pid.value}"
+    private fun cacheKey(pid: Pid, sjekkKunKjerneregler: Boolean): String =
+        "${navIdExtractor.id()}:${pid.value}:$sjekkKunKjerneregler"
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/PopulasjonstilgangService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/PopulasjonstilgangService.kt
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service
 class PopulasjonstilgangService(private val client: PopulasjonstilgangClient) {
     private val log = KotlinLogging.logger {}
 
-    fun sjekkTilgang(pid: Pid): TilgangResult =
+    fun sjekkTilgang(pid: Pid, sjekkKunKjerneregler: Boolean = false): TilgangResult =
         try {
-            client.sjekkTilgang(pid)
+            client.sjekkTilgang(pid, sjekkKunKjerneregler)
         } catch (e: Exception) {
             // Enhver feil skal gi 'tilgang avvist'
             "Populasjonstilgangssjekk feilet".let {

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/client/PopulasjonstilgangClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/client/PopulasjonstilgangClient.kt
@@ -4,5 +4,5 @@ import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tech.security.ingress.impersonal.access.folk.TilgangResult
 
 interface PopulasjonstilgangClient {
-    fun sjekkTilgang(pid: Pid): TilgangResult
+    fun sjekkTilgang(pid: Pid, sjekkKunKjerneregler: Boolean): TilgangResult
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/client/tilgangsmaskin/TilgangsmaskinClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/client/tilgangsmaskin/TilgangsmaskinClient.kt
@@ -35,9 +35,9 @@ class TilgangsmaskinClient(
     private val webClient = webClientBuilder.baseUrl(baseUrl).build()
     private val log = KotlinLogging.logger {}
 
-    override fun sjekkTilgang(pid: Pid): TilgangResult =
+    override fun sjekkTilgang(pid: Pid, sjekkKunKjerneregler: Boolean): TilgangResult =
         try {
-            val uri = "/$API_RESOURCE"
+            val uri = if (sjekkKunKjerneregler) "/$KJERNE_RESOURCE" else "/$KOMPLETT_RESOURCE"
             log.debug { "POST to URI: '$uri'" }
 
             webClient
@@ -90,7 +90,9 @@ class TilgangsmaskinClient(
     }
 
     companion object {
-        private const val API_RESOURCE = "api/v1/komplett"
+        private const val RESOURCE_BASE = "api/v1"
+        private const val KJERNE_RESOURCE = "$RESOURCE_BASE/kjerne"
+        private const val KOMPLETT_RESOURCE = "$RESOURCE_BASE/komplett"
         private val service = EgressService.TILGANGSMASKINEN
 
         private fun feilResultat(begrunnelse: String?) =

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/EpsServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/EpsServiceTest.kt
@@ -25,11 +25,7 @@ class EpsServiceTest : ShouldSpec({
             )
 
             EpsService(
-                client = mockk {
-                    every {
-                        fetchNyligsteEps(any(), any(), any())
-                    } returns familierelasjon
-                },
+                client = mockk { every { fetchNyligsteEps(any()) } returns familierelasjon },
                 personService = mockk(),
                 pidGetter = mockk(relaxed = true),
                 populasjonstilgangService = arrangeTilgang(tilgangsnektAarsak = null)
@@ -38,7 +34,7 @@ class EpsServiceTest : ShouldSpec({
     }
 
     context("nyligsteRelasjon - tilgang nektet") {
-        should("throw 'access denied' exception") {
+        should("kaste 'access denied' exception med beskrivelse av årsak") {
             shouldThrow<AccessDeniedException> {
                 EpsService(
                     client = mockk(relaxed = true),
@@ -52,4 +48,4 @@ class EpsServiceTest : ShouldSpec({
 })
 
 private fun arrangeTilgang(tilgangsnektAarsak: String?): CacheAwarePopulasjonstilgangService =
-    mockk { every { eventuellTilgangsnektAarsak(any()) } returns tilgangsnektAarsak }
+    mockk { every { eventuellTilgangsnektAarsak(any(), any()) } returns tilgangsnektAarsak }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/relasjon/eps/client/ppd/PensjonPersondataClientTest.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.kalkulator.person.relasjon.eps.client.ppd
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -12,6 +12,7 @@ import no.nav.pensjon.kalkulator.person.Tilgangsbegrensning
 import no.nav.pensjon.kalkulator.person.relasjon.Familierelasjon
 import no.nav.pensjon.kalkulator.person.relasjon.RelasjonPersondata
 import no.nav.pensjon.kalkulator.person.relasjon.Relasjonstype
+import no.nav.pensjon.kalkulator.person.relasjon.eps.client.NyligsteEpsSpec
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.testutil.Arrange
 import no.nav.pensjon.kalkulator.testutil.arrangeJsonResponse
@@ -24,7 +25,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClient
 import java.time.LocalDate
 
-class PensjonPersondataClientTest : FunSpec({
+class PensjonPersondataClientTest : ShouldSpec({
 
     var server: MockWebServer? = null
     var baseUrl: String? = null
@@ -34,6 +35,7 @@ class PensjonPersondataClientTest : FunSpec({
         PensjonPersondataClient(
             baseUrl!!,
             webClientBuilder = context.getBean<WebClient.Builder>(),
+            cacheManager = mockk(relaxed = true),
             traceAid,
             retryAttempts = "1"
         )
@@ -48,43 +50,51 @@ class PensjonPersondataClientTest : FunSpec({
         server?.shutdown()
     }
 
-    test("fetchNyligsteEps - suksess") {
-        server?.arrangeOkJsonResponse(OK_RESPONSE_BODY)
+    context("fetchNyligsteEps - suksess") {
+        should("returnere familierelasjon med angitte personalia hentet") {
+            server?.arrangeOkJsonResponse(OK_RESPONSE_BODY)
 
-        Arrange.webClientContextRunner().run {
-            client(context = it).fetchNyligsteEps(
-                soekerPid = pid,
-                sivilstatus = Sivilstatus.SAMBOER,
-                personaliaSpec = listOf(PersonaliaType.NAVN)
-            ) shouldBe Familierelasjon(
-                pid = pid,
-                fom = LocalDate.of(2021, 4, 1),
-                relasjonstype = Relasjonstype.SAMBOER,
-                relasjonPersondata = RelasjonPersondata(
-                    navn = Navn(fornavn = "F", mellomnavn = "M", etternavn = "E"),
-                    foedselsdato = null,
-                    doedsdato = null,
-                    statsborgerskap = null,
-                    tilgangsbegrensning = Tilgangsbegrensning.UNKNOWN
+            Arrange.webClientContextRunner().run {
+                client(context = it).fetchNyligsteEps(
+                    spec = NyligsteEpsSpec(
+                        soekerPid = pid,
+                        sivilstatus = Sivilstatus.SAMBOER,
+                        personalia = listOf(PersonaliaType.NAVN)
+                    )
+                ) shouldBe Familierelasjon(
+                    pid = pid,
+                    fom = LocalDate.of(2021, 4, 1),
+                    relasjonstype = Relasjonstype.SAMBOER,
+                    relasjonPersondata = RelasjonPersondata(
+                        navn = Navn(fornavn = "F", mellomnavn = "M", etternavn = "E"),
+                        foedselsdato = null,
+                        doedsdato = null,
+                        statsborgerskap = null,
+                        tilgangsbegrensning = Tilgangsbegrensning.UNKNOWN
+                    )
                 )
-            )
+            }
         }
     }
 
-    test("fetchNyligsteEps - EPS ikke funnet") {
-        server?.arrangeJsonResponse(HttpStatus.NOT_FOUND, "{}")
+    context("fetchNyligsteEps - EPS ikke funnet") {
+        should("returnere familierelasjon med relasjonstype 'ukjent' og øvrige data udefinert") {
+            server?.arrangeJsonResponse(HttpStatus.NOT_FOUND, "{}")
 
-        Arrange.webClientContextRunner().run {
-            client(context = it).fetchNyligsteEps(
-                soekerPid = pid,
-                sivilstatus = Sivilstatus.SAMBOER,
-                personaliaSpec = listOf(PersonaliaType.NAVN)
-            ) shouldBe Familierelasjon(
-                pid = null,
-                fom = null,
-                relasjonstype = Relasjonstype.UKJENT,
-                relasjonPersondata = null
-            )
+            Arrange.webClientContextRunner().run {
+                client(context = it).fetchNyligsteEps(
+                    spec = NyligsteEpsSpec(
+                        soekerPid = pid,
+                        sivilstatus = Sivilstatus.SAMBOER,
+                        personalia = listOf(PersonaliaType.NAVN)
+                    )
+                ) shouldBe Familierelasjon(
+                    pid = null,
+                    fom = null,
+                    relasjonstype = Relasjonstype.UKJENT,
+                    relasjonPersondata = null
+                )
+            }
         }
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/PopulasjonstilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/PopulasjonstilgangServiceTest.kt
@@ -17,11 +17,7 @@ class PopulasjonstilgangServiceTest : ShouldSpec({
             traceId = null
         )
 
-        PopulasjonstilgangService(
-            client = mockk<PopulasjonstilgangClient>().apply {
-                every { sjekkTilgang(any()) } returns result
-            }
-        ).sjekkTilgang(pid) shouldBe result
+        PopulasjonstilgangService(client = arrangeTilgang(result)).sjekkTilgang(pid) shouldBe result
     }
 
     should("gi 'tilgang avvist' når klienten gir 'tilgang avvist'") {
@@ -32,11 +28,7 @@ class PopulasjonstilgangServiceTest : ShouldSpec({
             traceId = "t"
         )
 
-        PopulasjonstilgangService(
-            client = mockk<PopulasjonstilgangClient>().apply {
-                every { sjekkTilgang(any()) } returns result
-            }
-        ).sjekkTilgang(pid) shouldBe result
+        PopulasjonstilgangService(client = arrangeTilgang(result)).sjekkTilgang(pid) shouldBe result
     }
 
     /**
@@ -45,8 +37,8 @@ class PopulasjonstilgangServiceTest : ShouldSpec({
      */
     should("gi 'tilgang avvist' når klienten feiler, og henvise til logg i begrunnelsen") {
         PopulasjonstilgangService(
-            client = mockk<PopulasjonstilgangClient>().apply {
-                every { sjekkTilgang(any()) } throws IllegalStateException("feil")
+            client = mockk {
+                every { sjekkTilgang(any(), any()) } throws IllegalStateException("feil")
             }
         ).sjekkTilgang(pid) shouldBe TilgangResult(
             innvilget = false,
@@ -56,3 +48,6 @@ class PopulasjonstilgangServiceTest : ShouldSpec({
         )
     }
 })
+
+private fun arrangeTilgang(result: TilgangResult): PopulasjonstilgangClient =
+    mockk { every { sjekkTilgang(any(), any()) } returns result }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/client/tilgangsmaskin/TilgangsmaskinClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/impersonal/access/folk/client/tilgangsmaskin/TilgangsmaskinClientTest.kt
@@ -43,20 +43,26 @@ class TilgangsmaskinClientTest : ShouldSpec({
         server?.shutdown()
     }
 
-    should("return innvilget when service returns 204 No Content") {
-        server?.arrangeNoContentResponse()
 
-        Arrange.webClientContextRunner().run {
-            val result = client(context = it, jsonMapper).sjekkTilgang(pid)
-            with(result) {
-                innvilget shouldBe true
-                avvisningAarsak shouldBe null
+    context("sjekk kun kjerneregler, tjenesten returnerer '204 No Content'") {
+        should("bruke 'kjerne' URL og returnere 'innvilget'") {
+            server?.arrangeNoContentResponse()
+
+            Arrange.webClientContextRunner().run {
+                val result = client(context = it, jsonMapper).sjekkTilgang(pid, sjekkKunKjerneregler = true)
+                with(result) {
+                    innvilget shouldBe true
+                    avvisningAarsak shouldBe null
+                }
+
+                server?.takeRequest()?.path shouldBe "/api/v1/kjerne"
             }
         }
     }
 
-    should("return avvist with details when service returns 403 Forbidden") {
-        val problemDetailJson = """
+    context("sjekk komplett regelsett, tjenesten returnerer '403 Forbidden'") {
+        should("bruke 'komplett' URL og returnere 'avvist' med beskrivelse av årsak") {
+            val problemDetailJson = """
             {
                 "type": "urn:tilgangsmaskin:avvist",
                 "title": "AVVIST_GEOGRAFISK",
@@ -70,15 +76,18 @@ class TilgangsmaskinClientTest : ShouldSpec({
             }
         """.trimIndent()
 
-        server?.arrangeJsonResponse(status = HttpStatus.FORBIDDEN, body = problemDetailJson)
+            server?.arrangeJsonResponse(status = HttpStatus.FORBIDDEN, body = problemDetailJson)
 
-        Arrange.webClientContextRunner().run {
-            client(context = it, jsonMapper).sjekkTilgang(pid) shouldBe TilgangResult(
-                innvilget = false,
-                avvisningAarsak = AvvisningAarsak.GEOGRAFISK,
-                begrunnelse = "Veileder har ikke tilgang til bruker i denne geografiske enheten",
-                traceId = "trace-123"
-            )
+            Arrange.webClientContextRunner().run {
+                client(context = it, jsonMapper).sjekkTilgang(pid, sjekkKunKjerneregler = false) shouldBe TilgangResult(
+                    innvilget = false,
+                    avvisningAarsak = AvvisningAarsak.GEOGRAFISK,
+                    begrunnelse = "Veileder har ikke tilgang til bruker i denne geografiske enheten",
+                    traceId = "trace-123"
+                )
+
+                server?.takeRequest()?.path shouldBe "/api/v1/komplett"
+            }
         }
     }
 })


### PR DESCRIPTION
Hovedendring:
- Innfører flagget `sjekkKunKjerneregler` i `PopulasjonstilgangService`, og setter dette til `true` ved tilgangssjekk for EPS.

I tillegg:
- Introduserer cache i `PensjonPersondataClient` for å unngå unødige kall til `pensjon-persondata`
- Nye dataklasser som fungerer som cache-nøkler: `NaavaerendeEpsSpec`, `NyligsteEpsSpec`, `TidligereStatusSpec`
- Noe refaktorering