### PR TITLE
TPP-510 Use encrypted PID in 'representasjon' call

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/kalkulator/normalder/NormertPensjonsalderService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/normalder/NormertPensjonsalderService.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.kalkulator.normalder
 
 import no.nav.pensjon.kalkulator.general.Alder
 import no.nav.pensjon.kalkulator.normalder.client.NormertPensjonsalderClient
+import no.nav.pensjon.kalkulator.tech.env.EnvironmentUtil.isDevelopment
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -22,7 +23,7 @@ class NormertPensjonsalderService(private val normalderClient: NormertPensjonsal
         )
 
     fun aldersgrenser(foedselsdato: LocalDate): Aldersgrenser =
-        if (System.getenv("NAIS_CLUSTER_NAME") == "dev-gcp")
+        if (isDevelopment())
             testAldersgrenser(foedselsdato)
         else
             normalderClient.fetchNormalderListe().first { it.aarskull == foedselsdato.year }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPid.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPid.kt
@@ -1,15 +1,15 @@
 package no.nav.pensjon.kalkulator.person
 
+import no.nav.pensjon.kalkulator.tech.crypto.EncryptionDetector.isEncryptedPid
+
 /**
  * Represents an encrypted person identifier.
  */
 data class EncryptedPid(val value: String) {
-    constructor(pid: PossiblyEncryptedPid) : this(validated(pid).value)
 
-    private companion object {
-        private fun validated(value: PossiblyEncryptedPid): PossiblyEncryptedPid {
-            require(value.isEncrypted) { "Expected encrypted PID" }
-            return value
-        }
+    constructor(pid: PossiblyEncryptedPid) : this(pid.value)
+
+    init {
+        require(isEncryptedPid(value)) { "Expected encrypted PID" }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPid.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPid.kt
@@ -1,0 +1,15 @@
+package no.nav.pensjon.kalkulator.person
+
+/**
+ * Represents an encrypted person identifier.
+ */
+data class EncryptedPid(val value: String) {
+    constructor(pid: PossiblyEncryptedPid) : this(validated(pid).value)
+
+    private companion object {
+        private fun validated(value: PossiblyEncryptedPid): PossiblyEncryptedPid {
+            require(value.isEncrypted) { "Expected encrypted PID" }
+            return value
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/person/PossiblyEncryptedPid.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/person/PossiblyEncryptedPid.kt
@@ -1,0 +1,10 @@
+package no.nav.pensjon.kalkulator.person
+
+import no.nav.pensjon.kalkulator.tech.crypto.EncryptionDetector.isEncryptedPid
+
+/**
+ * Represents a person identifier that may be encrypted.
+ */
+data class PossiblyEncryptedPid(val value: String) {
+    val isEncrypted: Boolean = isEncryptedPid(value)
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/crypto/EncryptionDetector.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/crypto/EncryptionDetector.kt
@@ -1,0 +1,9 @@
+package no.nav.pensjon.kalkulator.tech.crypto
+
+object EncryptionDetector {
+
+    private const val PID_ENCRYPTION_MARK = "."
+
+    fun isEncryptedPid(value: String): Boolean =
+        value.contains(PID_ENCRYPTION_MARK)
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/env/DevelopmentEnvironmentController.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/env/DevelopmentEnvironmentController.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.kalkulator.tech.env
 
+import no.nav.pensjon.kalkulator.tech.env.EnvironmentUtil.isDevelopment
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -22,8 +23,6 @@ class DevelopmentEnvironmentController {
 
     private companion object {
         private fun environmentVariable(name: String) =
-            if (System.getenv("NAIS_CLUSTER_NAME") == "dev-gcp")
-                System.getenv(name)
-            else "forbidden"
+            if (isDevelopment()) System.getenv(name) else "forbidden"
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/env/EnvironmentUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/env/EnvironmentUtil.kt
@@ -1,0 +1,10 @@
+package no.nav.pensjon.kalkulator.tech.env
+
+object EnvironmentUtil {
+
+    fun isDevelopment(): Boolean =
+        System.getenv()["NAIS_CLUSTER_NAME"] == "dev-gcp"
+
+    fun isProduction(): Boolean =
+        isDevelopment().not()
+}

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/Representasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/Representasjon.kt
@@ -1,6 +1,13 @@
 package no.nav.pensjon.kalkulator.tech.representasjon
 
+import no.nav.pensjon.kalkulator.person.Pid
+
 data class Representasjon(
     val isValid: Boolean,
-    val fullmaktGiverNavn: String
+    val fullmaktsgiver: Personalia?
+)
+
+data class Personalia(
+    val navn: String,
+    val pid: Pid
 )

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonService.kt
@@ -1,12 +1,22 @@
 package no.nav.pensjon.kalkulator.tech.representasjon
 
-import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.person.EncryptedPid
+import no.nav.pensjon.kalkulator.person.PossiblyEncryptedPid
+import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
 import no.nav.pensjon.kalkulator.tech.representasjon.client.RepresentasjonClient
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 
-@Component
-class RepresentasjonService(private val client: RepresentasjonClient) {
+@Service
+class RepresentasjonService(
+    private val client: RepresentasjonClient,
+    private val pidEncrypter: CryptoService
+) {
+    fun hasValidRepresentasjonsforhold(fullmaktsgiverPid: PossiblyEncryptedPid): Representasjon =
+        client.hasValidRepresentasjonsforhold(fullmaktsgiverPid = encrypted(fullmaktsgiverPid))
 
-    fun hasValidRepresentasjonsforhold(fullmaktGiverPid: Pid): Representasjon =
-        client.hasValidRepresentasjonsforhold(fullmaktGiverPid)
+    private fun encrypted(pid: PossiblyEncryptedPid): EncryptedPid =
+        if (pid.isEncrypted)
+            EncryptedPid(pid)
+        else
+            EncryptedPid(pidEncrypter.encrypt(pid.value))
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonService.kt
@@ -1,6 +1,8 @@
 package no.nav.pensjon.kalkulator.tech.representasjon
 
 import no.nav.pensjon.kalkulator.person.EncryptedPid
+import no.nav.pensjon.kalkulator.person.FoedselsnummerUtil.redact
+import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.person.PossiblyEncryptedPid
 import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
 import no.nav.pensjon.kalkulator.tech.representasjon.client.RepresentasjonClient
@@ -15,8 +17,9 @@ class RepresentasjonService(
         client.hasValidRepresentasjonsforhold(fullmaktsgiverPid = encrypted(fullmaktsgiverPid))
 
     private fun encrypted(pid: PossiblyEncryptedPid): EncryptedPid =
-        if (pid.isEncrypted)
-            EncryptedPid(pid)
-        else
-            EncryptedPid(pidEncrypter.encrypt(pid.value))
+        when {
+            pid.isEncrypted -> EncryptedPid(pid)
+            Pid(pid.value).isValid -> EncryptedPid(pidEncrypter.encrypt(pid.value))
+            else -> throw IllegalArgumentException("PID is invalid: ${redact(pid.value)}")
+        }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/RepresentasjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/RepresentasjonClient.kt
@@ -1,9 +1,9 @@
 package no.nav.pensjon.kalkulator.tech.representasjon.client
 
-import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.person.EncryptedPid
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 
 interface RepresentasjonClient {
 
-    fun hasValidRepresentasjonsforhold(fullmaktGiverPid: Pid): Representasjon
+    fun hasValidRepresentasjonsforhold(fullmaktsgiverPid: EncryptedPid): Representasjon
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.kalkulator.tech.representasjon.client.pensjon
 
 import mu.KotlinLogging
 import no.nav.pensjon.kalkulator.common.client.PingableServiceClient
-import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.person.EncryptedPid
 import no.nav.pensjon.kalkulator.tech.metric.MetricResult
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.representasjon.client.RepresentasjonClient
@@ -38,7 +38,7 @@ class PensjonRepresentasjonClient(
 
     private val log = KotlinLogging.logger {}
 
-    override fun hasValidRepresentasjonsforhold(fullmaktGiverPid: Pid): Representasjon {
+    override fun hasValidRepresentasjonsforhold(fullmaktsgiverPid: EncryptedPid): Representasjon {
         val uri = uri()
         log.debug { "GET from URI: '$uri'" }
 
@@ -47,7 +47,7 @@ class PensjonRepresentasjonClient(
                 .get()
                 .uri(uri)
                 .accept(MediaType.APPLICATION_JSON)
-                .headers { setHeaders(it, fullmaktGiverPid) }
+                .headers { setHeaders(it, fullmaktsgiverPid) }
                 .retrieve()
                 .bodyToMono<PensjonRepresentasjonResult>()
                 .retryWhen(retryBackoffSpec(uri))
@@ -80,10 +80,10 @@ class PensjonRepresentasjonClient(
             .build()
             .toUriString()
 
-    private fun setHeaders(headers: HttpHeaders, fullmaktGiverPid: Pid? = null) {
+    private fun setHeaders(headers: HttpHeaders, fullmaktsgiverPid: EncryptedPid) {
         headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
-        fullmaktGiverPid?.let { headers[CustomHttpHeaders.FULLMAKT_GIVER_PID] = it.value }
+        headers[CustomHttpHeaders.FULLMAKT_GIVER_PID] = fullmaktsgiverPid.value
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
@@ -102,6 +102,6 @@ class PensjonRepresentasjonClient(
         private val service = EgressService.PENSJON_REPRESENTASJON
 
         private fun noRepresentasjonForhold() =
-            Representasjon(isValid = false, fullmaktGiverNavn = "")
+            Representasjon(isValid = false, fullmaktsgiver = null)
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/dto/PensjonRepresentasjonResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/dto/PensjonRepresentasjonResult.kt
@@ -2,5 +2,6 @@ package no.nav.pensjon.kalkulator.tech.representasjon.client.pensjon.dto
 
 data class PensjonRepresentasjonResult(
     val hasValidRepresentasjonsforhold: Boolean?,
-    val fullmaktsgiverNavn: String?
+    val fullmaktsgiverNavn: String?,
+    val fullmaktsgiverFnr: String?
 )

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/map/PensjonRepresentasjonMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/map/PensjonRepresentasjonMapper.kt
@@ -1,13 +1,24 @@
 package no.nav.pensjon.kalkulator.tech.representasjon.client.pensjon.map
 
+import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.tech.representasjon.Personalia
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.representasjon.client.pensjon.dto.PensjonRepresentasjonResult
 
 object PensjonRepresentasjonMapper {
 
     fun fromDto(source: PensjonRepresentasjonResult) =
-        Representasjon(
-            isValid = source.hasValidRepresentasjonsforhold == true,
-            fullmaktGiverNavn = source.fullmaktsgiverNavn ?: ""
+        (source.hasValidRepresentasjonsforhold == true).let {
+            Representasjon(
+                isValid = it,
+                fullmaktsgiver = if (it) personalia(source) else null
+            )
+        }
+
+    private fun personalia(source: PensjonRepresentasjonResult) =
+        Personalia(
+            navn = source.fullmaktsgiverNavn ?: "(ukjent)",
+            pid = source.fullmaktsgiverFnr?.let(::Pid)
+                ?: throw IllegalArgumentException("Manglende PID for gyldig representasjon")
         )
 }

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricher.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricher.kt
@@ -10,6 +10,7 @@ import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
 import no.nav.pensjon.kalkulator.tech.crypto.EncryptionDetector.isEncryptedPid
 import no.nav.pensjon.kalkulator.tech.env.EnvironmentUtil.isProduction
 import no.nav.pensjon.kalkulator.tech.metric.Metrics
+import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonService
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonTarget
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentertRolle
@@ -70,21 +71,27 @@ class SecurityContextEnricher(
         auth: Authentication,
         request: HttpServletRequest
     ): Authentication =
-        onBehalfOfPid(request.cookies)?.let {
-            if (validRepresentasjonForhold(fullmaktsgiverPid = it))
-                enrichWithFullmakt(auth, fullmaktsgiverPid = Pid(decrypt(it.value))).also {
+        onBehalfOfPid(request.cookies)?.let { applyPotentialFullmakt(auth, pid = it) } ?: auth
+
+    private fun applyPotentialFullmakt(
+        auth: Authentication,
+        pid: PossiblyEncryptedPid
+    ): EnrichedAuthentication =
+        representasjon(fullmaktsgiverPid = pid).let {
+            if (it.isValid)
+                enrichWithFullmakt(auth, fullmaktsgiverPid = it.fullmaktsgiver!!.pid).also {
                     Metrics.countEvent(eventName = "obo", result = "ok")
                 }
             else
                 invalidRepresentasjonForhold()
-        } ?: auth
+        }
 
     /**
      * NB: Dette støtter ikke brukstilfellet der veileder er innlogget på vegne av en fullmektig.
      * Årsak: pensjon-representasjon henter ut fullmektigens PID fra TokenX-token (finnes ikke når veileder innlogget).
      */
-    private fun validRepresentasjonForhold(fullmaktsgiverPid: PossiblyEncryptedPid) =
-        representasjonService.hasValidRepresentasjonsforhold(fullmaktsgiverPid).isValid
+    private fun representasjon(fullmaktsgiverPid: PossiblyEncryptedPid): Representasjon =
+        representasjonService.hasValidRepresentasjonsforhold(fullmaktsgiverPid)
 
     private fun enrichWithFullmakt(auth: Authentication, fullmaktsgiverPid: Pid) =
         EnrichedAuthentication(
@@ -106,6 +113,10 @@ class SecurityContextEnricher(
             target = RepresentasjonTarget(rolle = RepresentertRolle.NONE)
         )
 
+    /**
+     * Header PID is used in 'veiledning' context.
+     * The PID has been encrypted by pensjon-pid-encryption.
+     */
     private fun headerPid(request: HttpServletRequest): Pid? =
         request.getHeader(CustomHttpHeaders.PID)?.let {
             when {
@@ -119,17 +130,15 @@ class SecurityContextEnricher(
             }
         }?.let(::Pid)
 
+    /**
+     * Cookie PID is used in 'representasjon' context.
+     * The PID has been encrypted by pensjon-representasjon (not by pensjon-pid-encryption).
+     */
     private fun onBehalfOfPid(cookies: Array<Cookie>?): PossiblyEncryptedPid? =
         cookies.orEmpty()
             .firstOrNull { ON_BEHALF_OF_COOKIE_NAME.equals(it.name, ignoreCase = true) }
             ?.value
             ?.let(::possiblyEncryptedPid)
-
-    private fun decrypt(value: String): String =
-        if (isEncryptedPid(value))
-            pidDecrypter.decrypt(value)
-        else
-            value
 
     private fun possiblyEncryptedPid(value: String) =
         PossiblyEncryptedPid(value).also {

--- a/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricher.kt
+++ b/src/main/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricher.kt
@@ -3,8 +3,12 @@ package no.nav.pensjon.kalkulator.tech.security.egress
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
 import no.nav.pensjon.kalkulator.person.Pid
+import no.nav.pensjon.kalkulator.person.PossiblyEncryptedPid
 import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
+import no.nav.pensjon.kalkulator.tech.crypto.EncryptionDetector.isEncryptedPid
+import no.nav.pensjon.kalkulator.tech.env.EnvironmentUtil.isProduction
 import no.nav.pensjon.kalkulator.tech.metric.Metrics
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonService
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonTarget
@@ -26,6 +30,8 @@ class SecurityContextEnricher(
     private val pidDecrypter: CryptoService,
     private val representasjonService: RepresentasjonService
 ) {
+    private val log = KotlinLogging.logger {}
+
     fun enrichAuthentication(request: HttpServletRequest, response: HttpServletResponse) {
         with(SecurityContextHolder.getContext()) {
             if (authentication == null) {
@@ -65,27 +71,26 @@ class SecurityContextEnricher(
         request: HttpServletRequest
     ): Authentication =
         onBehalfOfPid(request.cookies)?.let {
-            if (validRepresentasjonForhold(it))
-                enrichWithFullmakt(auth, it).also { Metrics.countEvent(eventName = "obo", result = "ok") }
+            if (validRepresentasjonForhold(fullmaktsgiverPid = it))
+                enrichWithFullmakt(auth, fullmaktsgiverPid = Pid(decrypt(it.value))).also {
+                    Metrics.countEvent(eventName = "obo", result = "ok")
+                }
             else
                 invalidRepresentasjonForhold()
         } ?: auth
 
     /**
-     * NB: Dette støtter ikke brukstilfellet der veileder er logget inn på vegne av en fullmektig.
-     * Dette fordi pensjon-representasjon henter ut PID fra TokenX-tokenet (som ikke finnes når veileder er logget inn).
+     * NB: Dette støtter ikke brukstilfellet der veileder er innlogget på vegne av en fullmektig.
+     * Årsak: pensjon-representasjon henter ut fullmektigens PID fra TokenX-token (finnes ikke når veileder innlogget).
      */
-    private fun validRepresentasjonForhold(pid: Pid) =
-        if (pid.isValid)
-            representasjonService.hasValidRepresentasjonsforhold(pid).isValid
-        else
-            false
+    private fun validRepresentasjonForhold(fullmaktsgiverPid: PossiblyEncryptedPid) =
+        representasjonService.hasValidRepresentasjonsforhold(fullmaktsgiverPid).isValid
 
-    private fun enrichWithFullmakt(auth: Authentication, fullmaktGiverPid: Pid) =
+    private fun enrichWithFullmakt(auth: Authentication, fullmaktsgiverPid: Pid) =
         EnrichedAuthentication(
             initialAuth = auth,
             egressTokenSuppliersByService = tokenSuppliers,
-            target = RepresentasjonTarget(pid = fullmaktGiverPid, rolle = RepresentertRolle.FULLMAKT_GIVER)
+            target = RepresentasjonTarget(pid = fullmaktsgiverPid, rolle = RepresentertRolle.FULLMAKT_GIVER)
         )
 
     private fun selv() =
@@ -105,7 +110,7 @@ class SecurityContextEnricher(
         request.getHeader(CustomHttpHeaders.PID)?.let {
             when {
                 hasLength(it).not() -> null
-                else -> if (it.contains(ENCRYPTION_MARK)) {
+                else -> if (isEncryptedPid(it)) {
                     with(SecurityContextHolder.getContext()) {
                         authentication = authentication?.let(::enrichTemporarily)
                         pidDecrypter.decrypt(it)
@@ -114,20 +119,25 @@ class SecurityContextEnricher(
             }
         }?.let(::Pid)
 
-    private fun onBehalfOfPid(cookies: Array<Cookie>?): Pid? =
+    private fun onBehalfOfPid(cookies: Array<Cookie>?): PossiblyEncryptedPid? =
         cookies.orEmpty()
-            .filter { ON_BEHALF_OF_COOKIE_NAME.equals(it.name, ignoreCase = true) }
-            .map { Pid((decrypt(it.value.orEmpty()))) }
-            .firstOrNull()
+            .firstOrNull { ON_BEHALF_OF_COOKIE_NAME.equals(it.name, ignoreCase = true) }
+            ?.value
+            ?.let(::possiblyEncryptedPid)
 
     private fun decrypt(value: String): String =
-        if (value.contains(ENCRYPTION_MARK))
+        if (isEncryptedPid(value))
             pidDecrypter.decrypt(value)
         else
             value
 
+    private fun possiblyEncryptedPid(value: String) =
+        PossiblyEncryptedPid(value).also {
+            if (isProduction() && it.isEncrypted.not())
+                log.warn { "Unencrypted PID received in OBO cookie" }
+        }
+
     private companion object {
-        private const val ENCRYPTION_MARK = "."
         private const val ON_BEHALF_OF_COOKIE_NAME = "nav-obo"
 
         private fun personUnderVeiledning(pid: Pid) =

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPidTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPidTest.kt
@@ -1,0 +1,22 @@
+package no.nav.pensjon.kalkulator.person
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+
+class EncryptedPidTest : ShouldSpec({
+
+    context("isEncrypted") {
+        context("kryptert PID") {
+            should("return 'true'") {
+                PossiblyEncryptedPid("contains.dot").isEncrypted shouldBe true
+            }
+        }
+
+        context("ukryptert PID") {
+            should("return 'false'") {
+                PossiblyEncryptedPid(pid.value).isEncrypted shouldBe false
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPidTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/EncryptedPidTest.kt
@@ -1,22 +1,37 @@
 package no.nav.pensjon.kalkulator.person
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
 
 class EncryptedPidTest : ShouldSpec({
 
-    context("isEncrypted") {
-        context("kryptert PID") {
-            should("return 'true'") {
-                PossiblyEncryptedPid("contains.dot").isEncrypted shouldBe true
-            }
+    context("argument is String with encrypted PID") {
+        should("accept value") {
+            EncryptedPid("contains.dot").value shouldBe "contains.dot"
         }
+    }
 
-        context("ukryptert PID") {
-            should("return 'false'") {
-                PossiblyEncryptedPid(pid.value).isEncrypted shouldBe false
-            }
+    context("argument is PossiblyEncryptedPid with encrypted PID") {
+        should("accept value") {
+            EncryptedPid(PossiblyEncryptedPid("contains.dot")).value shouldBe "contains.dot"
+        }
+    }
+
+    context("argument is String with unencrypted PID") {
+        should("throw 'illegal argument' exception") {
+            shouldThrow<IllegalArgumentException> {
+                EncryptedPid(pid.value)
+            }.message shouldBe "Expected encrypted PID"
+        }
+    }
+
+    context("argument is PossiblyEncryptedPid with unencrypted PID") {
+        should("throw 'illegal argument' exception") {
+            shouldThrow<IllegalArgumentException> {
+                EncryptedPid(PossiblyEncryptedPid(pid.value))
+            }.message shouldBe "Expected encrypted PID"
         }
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/person/PossiblyEncryptedPidTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/person/PossiblyEncryptedPidTest.kt
@@ -1,0 +1,22 @@
+package no.nav.pensjon.kalkulator.person
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+
+class PossiblyEncryptedPidTest : ShouldSpec({
+
+    context("isEncrypted") {
+        context("encrypted PID") {
+            should("return 'true'") {
+                PossiblyEncryptedPid("contains.dot").isEncrypted shouldBe true
+            }
+        }
+
+        context("unencrypted PID") {
+            should("return 'false'") {
+                PossiblyEncryptedPid(pid.value).isEncrypted shouldBe false
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonServiceTest.kt
@@ -1,0 +1,65 @@
+package no.nav.pensjon.kalkulator.tech.representasjon
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.person.PossiblyEncryptedPid
+import no.nav.pensjon.kalkulator.tech.representasjon.client.RepresentasjonClient
+
+class RepresentasjonServiceTest : ShouldSpec({
+
+    context("invalid representasjon") {
+        should("return 'not valid'") {
+            RepresentasjonService(
+                client = arrangeRepresentasjon(isValid = false),
+                pidEncrypter = mockk()
+            ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid(ENCRYPTED_PID)) shouldBe
+                    Representasjon(isValid = false, fullmaktGiverNavn = "F")
+        }
+    }
+
+    context("valid representasjon") {
+        context("valid representasjon - encrypted PID") {
+            should("return 'valid'") {
+                RepresentasjonService(
+                    client = arrangeRepresentasjon(isValid = true),
+                    pidEncrypter = mockk()
+                ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid(ENCRYPTED_PID)) shouldBe
+                        Representasjon(isValid = true, fullmaktGiverNavn = "F")
+            }
+        }
+
+        context("unencrypted valid PID") {
+            should("return 'valid'") {
+                RepresentasjonService(
+                    client = arrangeRepresentasjon(isValid = true),
+                    pidEncrypter = mockk { every { encrypt(any()) } returns ENCRYPTED_PID }
+                ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid(pid.value)) shouldBe
+                        Representasjon(isValid = true, fullmaktGiverNavn = "F")
+            }
+        }
+
+        context("unencrypted invalid PID") {
+            should("throw 'illegal argument' exception") {
+                shouldThrow<IllegalArgumentException> {
+                    RepresentasjonService(
+                        client = arrangeRepresentasjon(isValid = true),
+                        pidEncrypter = mockk()
+                    ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid("ugyldig"))
+                }.message shouldBe "PID is invalid: ugyldig"
+            }
+        }
+    }
+})
+
+private const val ENCRYPTED_PID = "contains.dot"
+
+private fun arrangeRepresentasjon(isValid: Boolean): RepresentasjonClient =
+    mockk {
+        every {
+            hasValidRepresentasjonsforhold(any())
+        } returns Representasjon(isValid, fullmaktGiverNavn = "F")
+    }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/RepresentasjonServiceTest.kt
@@ -17,7 +17,7 @@ class RepresentasjonServiceTest : ShouldSpec({
                 client = arrangeRepresentasjon(isValid = false),
                 pidEncrypter = mockk()
             ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid(ENCRYPTED_PID)) shouldBe
-                    Representasjon(isValid = false, fullmaktGiverNavn = "F")
+                    Representasjon(isValid = false, fullmaktsgiver = null)
         }
     }
 
@@ -28,7 +28,7 @@ class RepresentasjonServiceTest : ShouldSpec({
                     client = arrangeRepresentasjon(isValid = true),
                     pidEncrypter = mockk()
                 ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid(ENCRYPTED_PID)) shouldBe
-                        Representasjon(isValid = true, fullmaktGiverNavn = "F")
+                        Representasjon(isValid = true, fullmaktsgiver = fullmaktsgiver)
             }
         }
 
@@ -38,7 +38,7 @@ class RepresentasjonServiceTest : ShouldSpec({
                     client = arrangeRepresentasjon(isValid = true),
                     pidEncrypter = mockk { every { encrypt(any()) } returns ENCRYPTED_PID }
                 ).hasValidRepresentasjonsforhold(PossiblyEncryptedPid(pid.value)) shouldBe
-                        Representasjon(isValid = true, fullmaktGiverNavn = "F")
+                        Representasjon(isValid = true, fullmaktsgiver = fullmaktsgiver)
             }
         }
 
@@ -57,9 +57,11 @@ class RepresentasjonServiceTest : ShouldSpec({
 
 private const val ENCRYPTED_PID = "contains.dot"
 
+private val fullmaktsgiver = Personalia(navn = "F", pid)
+
 private fun arrangeRepresentasjon(isValid: Boolean): RepresentasjonClient =
     mockk {
         every {
             hasValidRepresentasjonsforhold(any())
-        } returns Representasjon(isValid, fullmaktGiverNavn = "F")
+        } returns Representasjon(isValid, fullmaktsgiver = if (isValid) fullmaktsgiver else null)
     }

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
@@ -1,9 +1,9 @@
 package no.nav.pensjon.kalkulator.tech.representasjon.client.pensjon
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
-import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.person.EncryptedPid
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.testutil.Arrange
@@ -12,7 +12,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.springframework.beans.factory.getBean
 import org.springframework.web.reactive.function.client.WebClient
 
-class PensjonRepresentasjonClientTest : FunSpec({
+class PensjonRepresentasjonClientTest : ShouldSpec({
 
     var server: MockWebServer? = null
     var baseUrl: String? = null
@@ -27,26 +27,28 @@ class PensjonRepresentasjonClientTest : FunSpec({
         server?.shutdown()
     }
 
-    test("hasValidRepresentasjonsforhold should return fullmaktsgiver if valid representasjon") {
-        server!!.arrangeOkJsonResponse("""{ "hasValidRepresentasjonsforhold": true, "fullmaktsgiverNavn": "Abc Æøå"}""")
+    context("valid representasjon") {
+        should("returnere fullmaktsgiver") {
+            server!!.arrangeOkJsonResponse("""{ "hasValidRepresentasjonsforhold": true, "fullmaktsgiverNavn": "Abc Æøå"}""")
 
-        Arrange.webClientContextRunner().run {
-            val client = PensjonRepresentasjonClient(
-                baseUrl = baseUrl!!,
-                webClientBuilder = it.getBean<WebClient.Builder>(),
-                traceAid = mockk<TraceAid>(relaxed = true),
-                retryAttempts = "0"
-            )
+            Arrange.webClientContextRunner().run {
+                val client = PensjonRepresentasjonClient(
+                    baseUrl = baseUrl!!,
+                    webClientBuilder = it.getBean<WebClient.Builder>(),
+                    traceAid = mockk<TraceAid>(relaxed = true),
+                    retryAttempts = "0"
+                )
 
-            client.hasValidRepresentasjonsforhold(pid) shouldBe
-                    Representasjon(isValid = true, fullmaktGiverNavn = "Abc Æøå")
+                client.hasValidRepresentasjonsforhold(fullmaktsgiverPid = EncryptedPid("kryptert.verdi")) shouldBe
+                        Representasjon(isValid = true, fullmaktGiverNavn = "Abc Æøå")
 
-            server.takeRequest().requestUrl?.query shouldBe
-                    "validRepresentasjonstyper=PENSJON_LES" +
-                    "&validRepresentasjonstyper=PENSJON_SKRIV" +
-                    "&validRepresentasjonstyper=VERGE_PENSJON_LES" +
-                    "&validRepresentasjonstyper=VERGE_PENSJON_SKRIV" +
-                    "&includeFullmaktsgiverNavn=false"
+                server.takeRequest().requestUrl?.query shouldBe
+                        "validRepresentasjonstyper=PENSJON_LES" +
+                        "&validRepresentasjonstyper=PENSJON_SKRIV" +
+                        "&validRepresentasjonstyper=VERGE_PENSJON_LES" +
+                        "&validRepresentasjonstyper=VERGE_PENSJON_SKRIV" +
+                        "&includeFullmaktsgiverNavn=false"
+            }
         }
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
@@ -3,12 +3,15 @@ package no.nav.pensjon.kalkulator.tech.representasjon.client.pensjon
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
+import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
 import no.nav.pensjon.kalkulator.person.EncryptedPid
+import no.nav.pensjon.kalkulator.tech.representasjon.Personalia
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.trace.TraceAid
 import no.nav.pensjon.kalkulator.testutil.Arrange
 import no.nav.pensjon.kalkulator.testutil.arrangeOkJsonResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.intellij.lang.annotations.Language
 import org.springframework.beans.factory.getBean
 import org.springframework.web.reactive.function.client.WebClient
 
@@ -29,7 +32,7 @@ class PensjonRepresentasjonClientTest : ShouldSpec({
 
     context("valid representasjon") {
         should("returnere fullmaktsgiver") {
-            server!!.arrangeOkJsonResponse("""{ "hasValidRepresentasjonsforhold": true, "fullmaktsgiverNavn": "Abc Æøå"}""")
+            server!!.arrangeOkJsonResponse(RESPONSE_BODY)
 
             Arrange.webClientContextRunner().run {
                 val client = PensjonRepresentasjonClient(
@@ -40,7 +43,7 @@ class PensjonRepresentasjonClientTest : ShouldSpec({
                 )
 
                 client.hasValidRepresentasjonsforhold(fullmaktsgiverPid = EncryptedPid("kryptert.verdi")) shouldBe
-                        Representasjon(isValid = true, fullmaktGiverNavn = "Abc Æøå")
+                        Representasjon(isValid = true, fullmaktsgiver = Personalia(navn = "Abc Æøå", pid))
 
                 server.takeRequest().requestUrl?.query shouldBe
                         "validRepresentasjonstyper=PENSJON_LES" +
@@ -52,3 +55,10 @@ class PensjonRepresentasjonClientTest : ShouldSpec({
         }
     }
 })
+
+@Language("JSON")
+private const val RESPONSE_BODY = """{
+  "hasValidRepresentasjonsforhold": true,
+  "fullmaktsgiverNavn": "Abc Æøå",
+  "fullmaktsgiverFnr": "12906498357"
+}"""

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricherTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricherTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
+import no.nav.pensjon.kalkulator.person.PossiblyEncryptedPid
 import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
@@ -96,6 +97,9 @@ class SecurityContextEnricherTest : ShouldSpec({
     }
 
     context("valid representasjon") {
+        /**
+         * NB: plaintext OBO cookie is only allowed in development environment; in production, OBO cookie is encrypted.
+         */
         should("set target PID from plaintext OBO cookie") {
             setSecurityContext(authentication = mockk())
 
@@ -140,7 +144,7 @@ class SecurityContextEnricherTest : ShouldSpec({
                     pidDecrypter = mockk(),
                     representasjonService = arrange(Representasjon(isValid = false, fullmaktGiverNavn = ""))
                 ).enrichAuthentication(
-                    request = arrangeOnBehalfOfCookie(PID),
+                    request = arrangeOnBehalfOfCookie(ENCRYPTED_PID),
                     response = mockk()
                 )
             }.message shouldBe "INVALID_REPRESENTASJON"
@@ -187,25 +191,29 @@ private fun securityContextTargetPid(): Pid? =
     SecurityContextHolder.getContext().authentication?.enriched()?.targetPid()
 
 private fun arrangeFoedselsnummer(value: String?): HttpServletRequest =
-    mockk<HttpServletRequest>(relaxed = true).apply {
+    mockk(relaxed = true) {
         every { getHeader("fnr") } returns value
     }
 
 private fun arrangeOnBehalfOfCookie(value: String): HttpServletRequest =
-    mockk<HttpServletRequest>(relaxed = true).apply {
+    mockk(relaxed = true) {
         every { cookies } returns listOf(Cookie("nav-obo", value)).toTypedArray()
     }
 
 private fun arrangeOnBehalfOfCookieAndHeader(): HttpServletRequest =
-    mockk<HttpServletRequest>(relaxed = true).apply {
+    mockk(relaxed = true) {
         every { getHeader("fnr") } returns PID
-        every { cookies } returns listOf(Cookie("nav-obo", PID)).toTypedArray()
+        every { cookies } returns listOf(Cookie("nav-obo", ENCRYPTED_PID)).toTypedArray()
     }
 
 private fun arrange(representasjon: Representasjon): RepresentasjonService =
     mockk {
         every {
-            hasValidRepresentasjonsforhold(fullmaktGiverPid = Pid(PID))
+            hasValidRepresentasjonsforhold(fullmaktsgiverPid = PossiblyEncryptedPid(ENCRYPTED_PID))
+        } returns representasjon
+
+        every {
+            hasValidRepresentasjonsforhold(fullmaktsgiverPid = PossiblyEncryptedPid(PID)) // use case in dev only
         } returns representasjon
     }
 

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricherTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/egress/SecurityContextEnricherTest.kt
@@ -13,6 +13,7 @@ import no.nav.pensjon.kalkulator.mock.PersonFactory.pid
 import no.nav.pensjon.kalkulator.person.PossiblyEncryptedPid
 import no.nav.pensjon.kalkulator.person.Pid
 import no.nav.pensjon.kalkulator.tech.crypto.CryptoService
+import no.nav.pensjon.kalkulator.tech.representasjon.Personalia
 import no.nav.pensjon.kalkulator.tech.representasjon.Representasjon
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonService
 import no.nav.pensjon.kalkulator.tech.representasjon.RepresentasjonTarget
@@ -107,7 +108,7 @@ class SecurityContextEnricherTest : ShouldSpec({
                 tokenSuppliers,
                 securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
                 pidDecrypter = mockk(),
-                representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
+                representasjonService = arrange(validRepresentasjon)
             ).enrichAuthentication(
                 request = arrangeOnBehalfOfCookie(PID),
                 response = mockk()
@@ -123,7 +124,7 @@ class SecurityContextEnricherTest : ShouldSpec({
                 tokenSuppliers,
                 securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
                 pidDecrypter = arrangeDecryption(),
-                representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
+                representasjonService = arrange(validRepresentasjon)
             ).enrichAuthentication(
                 request = arrangeOnBehalfOfCookie(ENCRYPTED_PID),
                 response = mockk()
@@ -142,7 +143,7 @@ class SecurityContextEnricherTest : ShouldSpec({
                     tokenSuppliers,
                     securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
                     pidDecrypter = mockk(),
-                    representasjonService = arrange(Representasjon(isValid = false, fullmaktGiverNavn = ""))
+                    representasjonService = arrange(Representasjon(isValid = false, fullmaktsgiver = null))
                 ).enrichAuthentication(
                     request = arrangeOnBehalfOfCookie(ENCRYPTED_PID),
                     response = mockk()
@@ -182,6 +183,12 @@ class SecurityContextEnricherTest : ShouldSpec({
 
 private const val PID = "12906498357"
 private const val ENCRYPTED_PID = "contains.dot"
+
+private val validRepresentasjon =
+    Representasjon(
+        isValid = true,
+        fullmaktsgiver = Personalia(navn = "F. Giver", pid)
+    )
 
 private fun setSecurityContext(authentication: Authentication) {
     SecurityContextHolder.setContext(SecurityContextImpl(authentication))

--- a/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/kalkulator/tech/security/ingress/SecurityLevelFilterTest.kt
@@ -143,24 +143,16 @@ class SecurityLevelFilterTest : ShouldSpec({
 })
 
 private fun arrangeFilterChain(request: HttpServletRequest, response: HttpServletResponse): FilterChain =
-    mockk<FilterChain>().apply {
-        every { doFilter(request, response) } returns Unit
-    }
+    mockk { every { doFilter(request, response) } returns Unit }
 
 private fun arrangeAdressebeskyttelse(gradering: AdressebeskyttelseGradering): FortroligAdresseService =
-    mockk<FortroligAdresseService>().apply {
-        every { adressebeskyttelseGradering(any()) } returns gradering
-    }
+    mockk { every { adressebeskyttelseGradering(any()) } returns gradering }
 
 private fun arrangeRequest(uri: String = "/api/foo"): HttpServletRequest =
-    mockk<HttpServletRequest>().apply {
-        every { requestURI } returns uri
-    }
+    mockk { every { requestURI } returns uri }
 
 private fun arrangeResponse(printWriter: PrintWriter = mockk()): HttpServletResponse =
-    mockk<HttpServletResponse>().apply {
-        every { writer } returns printWriter
-    }
+    mockk { every { writer } returns printWriter }
 
 private fun arrangeForbiddenResponse(printWriter: PrintWriter): HttpServletResponse =
     arrangeResponse(printWriter).apply {
@@ -169,9 +161,7 @@ private fun arrangeForbiddenResponse(printWriter: PrintWriter): HttpServletRespo
     }
 
 private fun arrangeWriter(): PrintWriter =
-    mockk<PrintWriter>().apply {
-        every { append("""{ "reason": "INSUFFICIENT_LEVEL_OF_ASSURANCE" }""") } returns this
-    }
+    mockk { every { append("""{ "reason": "INSUFFICIENT_LEVEL_OF_ASSURANCE" }""") } returns this }
 
 private fun arrangeSecurity(securityLevel: String, rolle: RepresentertRolle) {
     SecurityContextHolder.setContext(
@@ -179,7 +169,7 @@ private fun arrangeSecurity(securityLevel: String, rolle: RepresentertRolle) {
             EnrichedAuthentication(
                 initialAuth = MockAuthentication(claimKey = "acr", claimValue = securityLevel),
                 egressTokenSuppliersByService = EgressTokenSuppliersByService(emptyMap()),
-                target = RepresentasjonTarget(pid = null, rolle)
+                target = RepresentasjonTarget(pid = null, rolle = rolle)
             )
         )
     )


### PR DESCRIPTION
Fikser en bug relatert til fullmakt (representasjon) i ekstern kalkulator.

### Bakgrunn

Cookien `nav-obo` inneholder kryptert PID (fødselsnummer) for fullmaktsgiver. Det er fullmaktgivers data som skal vises når fullmektig er innlogget, og det finnes et gyldig fullmaktsforhold.

Den krypterte PID dekrypteres for intern bruk i backend (hvilket er OK), men for kall til pensjon-representasjon skal den krypterte verdien brukes.

NB: I dev-miljø er det tillatt med ukryptert PID.

### Endringer

- Innfører en felles `EnvironmentUtil`-klasse for å sjekke om man er i dev/prod-miljø
- Oppretter to klasser for å håndtere "mulig kryptert PID": `PossiblyEncryptedPid` (aksepterer både kryptert og ukryptert) og `EncryptedPid` (her må verdien være kryptert)
- Cookien tillates å ha både kryptert og ukryptert verdi, men i prod logges det en warning hvis ukryptert
- Kall til `hasValidRepresentasjonsforhold` gjøres med kryptert PID i både dev og prod
- Navneendring: `fullmaktGiverPid` -> `fullmaktsgiverPid`